### PR TITLE
CODAP-1504: draw and hit test point shapes in the canvas renderer

### DIFF
--- a/v3/src/components/data-display/data-display-types.ts
+++ b/v3/src/components/data-display/data-display-types.ts
@@ -4,6 +4,8 @@ import {GraphPlace} from "../axis-graph-shared"
 import { ICase } from "../../models/data/data-set-types"
 
 export type Point = { x: number, y: number }
+// width and height without a position, for sizing something against a box
+export type Extent = { w: number, h: number }
 export type CPLine = { slope: number, intercept: number, pivot1?: Point, pivot2?: Point }
 export const kNullPoint = {x: -999, y: -999}
 

--- a/v3/src/components/data-display/data-display-utils.test.ts
+++ b/v3/src/components/data-display/data-display-utils.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../utilities/color-utils"
 import { GraphDataConfigurationModel } from "../graph/models/graph-data-configuration-model"
 import { IPointStyle, PointRendererBase } from "./renderer"
-import { getCasesForDelta, setPointSelection } from "./data-display-utils"
+import { getCasesForDelta, matchCirclesToData, setPointSelection } from "./data-display-utils"
 
 const TreeModel = types.model("Tree", {
   data: DataSet,
@@ -298,5 +298,70 @@ describe("getCasesForDelta", () => {
 
   it("returns [] when the tree is null", () => {
     expect(getCasesForDelta(null, { x: 0, y: 0, w: 1, h: 1 }, { x: 0, y: 0, w: 1, h: 1 })).toEqual([])
+  })
+})
+
+describe("matchCirclesToData", () => {
+  /*
+   * This is where a point is created, and several callers create points without refreshing in the
+   * same breath -- they rely on the resulting case-data change to trigger a refresh later. A point
+   * born without a shape is drawn as a circle until that happens.
+   */
+  it("creates points with the display's shape, as it does with its color", () => {
+    const tree = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    tree.data.addAttribute({ id: "xId", name: "x" })
+    tree.metadata.setData(tree.data)
+    tree.data.addCases(toCanonical(tree.data, [{ __id__: "c1", x: 1 }]))
+    tree.config.setDataset(tree.data, tree.metadata)
+
+    let defaultStyle: Partial<IPointStyle> | undefined
+    const renderer = {
+      matchPointsToData: (_dataId: string, _cases: any, _type: any, style: Partial<IPointStyle>) => {
+        defaultStyle = style
+      }
+    } as unknown as PointRendererBase
+
+    matchCirclesToData({
+      dataConfiguration: tree.config,
+      renderer,
+      pointRadius: 5,
+      pointColor: "#123456",
+      pointShape: "star",
+      pointStrokeColor: "#000000",
+      startAnimation: jest.fn(),
+      stopAnimation: jest.fn(),
+      instanceId: "test"
+    })
+
+    expect(defaultStyle?.shape).toBe("star")
+    expect(defaultStyle?.fill).toBe("#123456")
+  })
+
+  it("creates circles when no shape is supplied", () => {
+    const tree = TreeModel.create({ data: {}, metadata: {}, config: {} })
+    tree.data.addAttribute({ id: "xId", name: "x" })
+    tree.metadata.setData(tree.data)
+    tree.data.addCases(toCanonical(tree.data, [{ __id__: "c1", x: 1 }]))
+    tree.config.setDataset(tree.data, tree.metadata)
+
+    let defaultStyle: Partial<IPointStyle> | undefined
+    const renderer = {
+      matchPointsToData: (_dataId: string, _cases: any, _type: any, style: Partial<IPointStyle>) => {
+        defaultStyle = style
+      }
+    } as unknown as PointRendererBase
+
+    matchCirclesToData({
+      dataConfiguration: tree.config,
+      renderer,
+      pointRadius: 5,
+      pointColor: "#123456",
+      pointStrokeColor: "#000000",
+      startAnimation: jest.fn(),
+      stopAnimation: jest.fn(),
+      instanceId: "test"
+    })
+
+    expect(defaultStyle?.shape).toBe("circle")
   })
 })

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -15,6 +15,7 @@ import {
   pointRadiusSelectionAddend, Rect, rTreeRect
 } from "./data-display-types"
 import {IDataConfigurationModel } from "./models/data-configuration-model"
+import { IDisplayItemDescriptionModel } from "./models/display-item-description-model"
 import {CaseDataWithSubPlot} from "./d3-types"
 import { getRendererForEvent, IPoint, IPointStyle, PointRendererBase } from "./renderer"
 
@@ -77,15 +78,25 @@ export const handleClickOnBar = ({ event, dataConfig, barCover }: IHandleClickOn
   setOrExtendSelection(barCover.caseIDs, dataConfig.dataset, extendSelection)
 }
 
+/*
+ * The shape for each case: the one its legend category carries, and the display's own wherever the
+ * legend assigns none. Every path that draws points needs this, so it is built here rather than
+ * rebuilt identically at each of them.
+ */
+export function legendShapeGetter(
+  dataConfig: IDataConfigurationModel | undefined, displayItemDescription: IDisplayItemDescriptionModel
+): (caseID: string) => PointShape {
+  const shapeIfNoCategory = displayItemDescription.pointShape
+  return (caseID: string) =>
+    dataConfig?.getLegendShapeForCase(caseID, shapeIfNoCategory) ?? shapeIfNoCategory
+}
+
 export interface IMatchCirclesProps {
   dataConfiguration: IDataConfigurationModel
   pointRadius: number
   pointColor: string
-  /*
-   * The shape a point is created with, as pointColor is the color it is created with. The refresh
-   * that follows resolves the per-case shape; this is what the point is drawn as until it does, and
-   * several callers create points without refreshing in the same breath.
-   */
+  // The shape a point is created with, as pointColor is the color it is created with. Several
+  // callers create points without refreshing in the same breath.
   pointShape?: PointShape
   pointDisplayType?: PointDisplayType
   pointStrokeColor: string
@@ -157,8 +168,6 @@ export function setPointSelection(
     // When there's no legend, use blue fill for selection instead of a colored stroke
     const useSelectionFill = isSelected && !legendID
     const style: Partial<IPointStyle> = {
-      // Mirrors the fill above: the legend assigns it per case where it can, and the display's own
-      // shape applies everywhere else.
       shape: dataConfiguration.getLegendShapeForCase(caseID, pointShape),
       fill: useSelectionFill ? defaultSelectedColor : fill,
       radius: isSelected ? selectedPointRadius : pointRadius,

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -6,6 +6,7 @@ import {
   defaultStrokeOpacity, defaultStrokeWidth
 } from "../../utilities/color-utils"
 import {between} from "../../utilities/math-utils"
+import { kDefaultPointShape, PointShape } from "../../utilities/point-shape-utils"
 import { IBarCover } from "../graph/graphing-types"
 import {isGraphDataConfigurationModel} from "../graph/models/graph-data-configuration-model"
 import {ISetPointSelection} from "../graph/utilities/graph-utils"
@@ -80,6 +81,12 @@ export interface IMatchCirclesProps {
   dataConfiguration: IDataConfigurationModel
   pointRadius: number
   pointColor: string
+  /*
+   * The shape a point is created with, as pointColor is the color it is created with. The refresh
+   * that follows resolves the per-case shape; this is what the point is drawn as until it does, and
+   * several callers create points without refreshing in the same breath.
+   */
+  pointShape?: PointShape
   pointDisplayType?: PointDisplayType
   pointStrokeColor: string
   startAnimation: () => void
@@ -90,7 +97,7 @@ export interface IMatchCirclesProps {
 
 export function matchCirclesToData(props: IMatchCirclesProps) {
   const { dataConfiguration, renderer, startAnimation, stopAnimation, pointRadius, pointColor, pointStrokeColor,
-          pointDisplayType = "points" } = props
+          pointShape = kDefaultPointShape, pointDisplayType = "points" } = props
   // TODO: eliminate dependence on GraphDataConfigurationModel
   const allCaseData: CaseDataWithSubPlot[] = isGraphDataConfigurationModel(dataConfiguration)
     ? dataConfiguration.caseDataWithSubPlot
@@ -111,6 +118,7 @@ export function matchCirclesToData(props: IMatchCirclesProps) {
   renderer?.matchPointsToData(dataConfiguration.dataset?.id ?? '', allCaseData, pointDisplayType, {
     radius: pointRadius,
     fill: pointColor,
+    shape: pointShape,
     stroke: pointStrokeColor,
     strokeWidth: defaultStrokeWidth
   })

--- a/v3/src/components/data-display/data-display-utils.ts
+++ b/v3/src/components/data-display/data-display-utils.ts
@@ -130,7 +130,7 @@ export function setPointSelection(
   props: ISetPointSelection, caseIdsToUpdate?: Iterable<string>, numberOfPlots = 1
 ) {
   const { renderer, dataConfiguration, pointRadius, selectedPointRadius,
-    pointColor, pointStrokeColor, getPointColorAtIndex } = props
+    pointColor, pointStrokeColor, pointShape, getPointColorAtIndex } = props
   const dataset = dataConfiguration.dataset
   const legendID = dataConfiguration.attributeID('legend')
   if (!renderer) {
@@ -149,6 +149,9 @@ export function setPointSelection(
     // When there's no legend, use blue fill for selection instead of a colored stroke
     const useSelectionFill = isSelected && !legendID
     const style: Partial<IPointStyle> = {
+      // Mirrors the fill above: the legend assigns it per case where it can, and the display's own
+      // shape applies everywhere else.
+      shape: dataConfiguration.getLegendShapeForCase(caseID, pointShape),
       fill: useSelectionFill ? defaultSelectedColor : fill,
       radius: isSelected ? selectedPointRadius : pointRadius,
       stroke: isSelected && !useSelectionFill ? defaultSelectedStroke : pointStrokeColor,

--- a/v3/src/components/data-display/inspector/display-item-format-control.scss
+++ b/v3/src/components/data-display/inspector/display-item-format-control.scss
@@ -297,6 +297,30 @@
       }
     }
 
+    // A row carrying both a shape control and a color control -- every category row, and the
+    // single Points row shown when there is no legend attribute. Without this the row distributes
+    // with space-between and each control starts wherever its label happens to end, so the rows
+    // do not line up with each other.
+    .cat-color-picker,
+    .color-picker-row.shape-row {
+      gap: 4px;
+
+      // Only the label may shrink; the controls keep their size.
+      .react-aria-Select {
+        flex: 0 0 auto;
+      }
+
+      // Absorbs the free space, which pins both controls to the right edge. Truncates rather than
+      // pushing them out of view.
+      .form-label.color-picker {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+
     .cat-color-setting {
       // A flex column, so the rows are flex items whose vertical margins do not collapse and each
       // row occupies the full height the 2.5-row limit below is derived from. The list ends
@@ -333,22 +357,6 @@
       .cat-color-picker {
         flex-shrink: 0; // rows keep their height, so the list scrolls rather than compressing
         margin: vars.$palette-category-row-margin 0;
-        gap: 4px;
-
-        // Only the label may shrink; the controls keep their size.
-        .react-aria-Select {
-          flex: 0 0 auto;
-        }
-
-        // Absorbs the free space so the controls align across rows rather than each starting
-        // wherever its category name happens to end. Truncates rather than pushing them out.
-        .form-label.color-picker {
-          flex: 1;
-          min-width: 0;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
       }
     }
 

--- a/v3/src/components/data-display/inspector/legend-color-controls.test.tsx
+++ b/v3/src/components/data-display/inspector/legend-color-controls.test.tsx
@@ -651,7 +651,7 @@ describe("point shape controls", () => {
       )
 
       expect(screen.getByTestId("point-shape-select")).toBeInTheDocument()
-      // the legend's own colour controls are still there
+      // the legend's own color controls are still there
       expect(screen.getByTestId("color-swatch-DG.Inspector.legendColorLow")).toBeInTheDocument()
     })
 

--- a/v3/src/components/data-display/inspector/legend-color-controls.tsx
+++ b/v3/src/components/data-display/inspector/legend-color-controls.tsx
@@ -224,7 +224,8 @@ export const LegendColorControls = observer(function LegendColorControls(
   // every point and sit in a single row.
   const singleRowLabel = showShape ? t("V3.Inspector.points") : t("DG.Inspector.color")
   return (
-    <div className="palette-row color-picker-row">
+    // shape-row marks a row carrying both controls, so it aligns them the way the category rows do
+    <div className={clsx("palette-row", "color-picker-row", { "shape-row": showShape })}>
       <label className="form-label color-picker">{singleRowLabel}</label>
       <If condition={showShape}>
         <PointShapeSetting propertyLabel={t("V3.Inspector.pointShape")}

--- a/v3/src/components/data-display/inspector/legend-color-controls.tsx
+++ b/v3/src/components/data-display/inspector/legend-color-controls.tsx
@@ -182,6 +182,9 @@ export const LegendColorControls = observer(function LegendColorControls(
         categories={categoriesRef.current}
         dataConfiguration={dataConfiguration}
         showShape={showShape}
+        // A category with no shape of its own draws the display's, so the control has to show that
+        // rather than the bare default, or it would disagree with the plot.
+        shapeIfUnset={displayItemDescription.pointShape}
         onCatPointColorChange={handleCatPointColorChange}
         onCatPointShapeChange={handleCatPointShapeChange}
       />
@@ -244,12 +247,13 @@ interface ICategoricalColorControlsProps {
   categories?: string[]
   dataConfiguration: IDataConfigurationModel
   showShape: boolean
+  shapeIfUnset: PointShape
   onCatPointColorChange: (color: string, cat: string) => void
   onCatPointShapeChange: (shape: PointShape, cat: string) => void
 }
 
 const CategoricalColorControls = observer(function CategoricalColorControls(
-  { categories, dataConfiguration, showShape, onCatPointColorChange, onCatPointShapeChange }:
+  { categories, dataConfiguration, showShape, shapeIfUnset, onCatPointColorChange, onCatPointShapeChange }:
     ICategoricalColorControlsProps
 ) {
   const [scrollVersion, setScrollVersion] = useState(0)
@@ -266,7 +270,7 @@ const CategoricalColorControls = observer(function CategoricalColorControls(
           <If condition={showShape}>
             <PointShapeSetting propertyLabel={category}
               closeTrigger={scrollVersion}
-              shape={dataConfiguration.getLegendShapeForCategory(category)}
+              shape={dataConfiguration.getLegendShapeForCategory(category, shapeIfUnset)}
               color={dataConfiguration.getLegendColorForCategory(category)}
               onShapeChange={(shape) => onCatPointShapeChange(shape, category)}/>
           </If>

--- a/v3/src/components/data-display/inspector/point-shape-setting.tsx
+++ b/v3/src/components/data-display/inspector/point-shape-setting.tsx
@@ -117,7 +117,7 @@ export const PointShapeSetting = observer(function PointShapeSetting({
         * trigger it always appears, clipping and scrolling within its own max-height, which is
         * the lesser failure.
         *
-        * The colour picker in this same palette disables flipping for the same reason, so the
+        * The color picker in this same palette disables flipping for the same reason, so the
         * fault lies in how popovers position within the palette rather than in this control.
         */}
       <Popover shouldFlip={false}

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -890,6 +890,16 @@ export const DataConfigurationModel = types
        * For categorical it is a map of categories to colors
        * The color type is not handled yet.
        */
+      /*
+       * Changes identity when any category's shape changes, so a display can react to it the way
+       * it reacts to legendColorDomain. Only categorical legends carry shapes; the rest have no
+       * categories to assign one to, so there is nothing to observe.
+       */
+      get legendShapeDomain() {
+        const legendType = self.attributeType('legend')
+        if (legendType !== 'categorical' && legendType !== 'checkbox') return undefined
+        return self.categorySetForAttrRole('legend')?.shapeMap
+      },
       get legendColorDomain() {
         const legendType = self.attributeType('legend')
         switch (legendType) {

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -866,10 +866,9 @@ export const DataConfigurationModel = types
        * A point then stands for several children at once, and resolving the legend through any one
        * of them would attribute that child's value to the whole group, so callers fall back.
        *
-       * Lives a block above the two views that use it so they can reach it through `self`. They are
-       * routinely passed around as detached function references -- a plot hands
-       * `dataConfig.getLegendColorForCase` to setPointCoordinates, which calls it bare -- so `this`
-       * inside them is undefined and cannot be used to reach a sibling view.
+       * Must stay a block above the views that use it, so they reach it through `self`. They are
+       * passed around as detached function references -- a plot hands `getLegendColorForCase` to
+       * setPointCoordinates, which calls it bare -- so `this` inside them is undefined.
        */
       get legendCollectionIsMoreChildmost(): boolean {
         const legendID = self.attributeID('legend')
@@ -910,11 +909,8 @@ export const DataConfigurationModel = types
        * For categorical it is a map of categories to colors
        * The color type is not handled yet.
        */
-      /*
-       * Changes identity when any category's shape changes, so a display can react to it the way
-       * it reacts to legendColorDomain. Only categorical legends carry shapes; the rest have no
-       * categories to assign one to, so there is nothing to observe.
-       */
+      // Changes identity when any category's shape changes, so a display can react to it the way it
+      // reacts to legendColorDomain.
       get legendShapeDomain() {
         const legendType = self.attributeType('legend')
         if (legendType !== 'categorical' && legendType !== 'checkbox') return undefined
@@ -970,10 +966,9 @@ export const DataConfigurationModel = types
       /*
        * The shape for a case, mirroring getLegendColorForCase.
        *
-       * Only categorical legends carry shapes. A numeric or date legend has no categories to assign
-       * one to, and a color legend supplies its own colors; those all resolve to the default so
-       * every point in such a plot shares one shape. Callers pass the display's own shape as
-       * `shapeIfNoCategory`, which is what a plot with no legend attribute uses throughout.
+       * Only a categorical legend has categories to carry shapes, so every other kind resolves to
+       * `shapeIfNoCategory` -- the display's own shape, which is also what a plot with no legend
+       * attribute draws throughout.
        */
       getLegendShapeForCase(id: string, shapeIfNoCategory: PointShape = kDefaultPointShape): PointShape {
         const legendID = self.attributeID('legend')

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -960,7 +960,7 @@ export const DataConfigurationModel = types
        * The shape for a case, mirroring getLegendColorForCase.
        *
        * Only categorical legends carry shapes. A numeric or date legend has no categories to assign
-       * one to, and a colour legend supplies its own colours; those all resolve to the default so
+       * one to, and a color legend supplies its own colors; those all resolve to the default so
        * every point in such a plot shares one shape. Callers pass the display's own shape as
        * `shapeIfNoCategory`, which is what a plot with no legend attribute uses throughout.
        */

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -919,16 +919,20 @@ export const DataConfigurationModel = types
             return 0
         }
       },
+      /*
+       * Whether the legend attribute lives in a collection more childmost than the plotted cases.
+       * A point then stands for several children at once, and resolving the legend through any one
+       * of them would attribute that child's value to the whole group, so callers fall back.
+       */
+      get legendCollectionIsMoreChildmost(): boolean {
+        const legendID = self.attributeID('legend')
+        const legendCollectionID = self.dataset?.getCollectionForAttribute(legendID)?.id
+        const legendCollectionIndex = self.dataset?.getCollectionIndex(legendCollectionID) ?? 0
+        const childmostCollectionID = idOfChildmostCollectionForAttributes(self.axisAttributeIDs, self.dataset)
+        const childmostCollectionIndex = self.dataset?.getCollectionIndex(childmostCollectionID) ?? 0
+        return legendCollectionIndex > childmostCollectionIndex
+      },
       getLegendColorForCase(id: string, colorIfMissing = missingColor): string {
-
-        const collectionOfLegendIsMoreChildmost = () => {
-          const legendCollectionID = self.dataset?.getCollectionForAttribute(legendID)?.id,
-            legendCollectionIndex = self.dataset?.getCollectionIndex(legendCollectionID) ?? 0,
-            childmostCollectionID = idOfChildmostCollectionForAttributes(self.axisAttributeIDs, self.dataset),
-            childmostCollectionIndex = self.dataset?.getCollectionIndex(childmostCollectionID) ?? 0
-          return legendCollectionIndex > childmostCollectionIndex
-        }
-
         const legendID = self.attributeID('legend')
         // todo: When user deletes we are not currently deleting the legend attribute ID. But we should.
         const legendAttribute = self.dataset?.getAttribute(legendID)
@@ -936,7 +940,7 @@ export const DataConfigurationModel = types
           return ''
         }
         const legendType = self.attributeType('legend')
-        if (collectionOfLegendIsMoreChildmost()) {
+        if (this.legendCollectionIsMoreChildmost) {
           return colorIfMissing
         }
         const legendValue = self.dataset?.getStrValue(id, legendID)
@@ -973,6 +977,9 @@ export const DataConfigurationModel = types
 
         const legendType = self.attributeType('legend')
         if (legendType !== 'categorical' && legendType !== 'checkbox') return shapeIfNoCategory
+
+        // as for color: a legend below the plotted cases cannot speak for a parent-level point
+        if (this.legendCollectionIsMoreChildmost) return shapeIfNoCategory
 
         const legendValue = self.dataset?.getStrValue(id, legendID)
         if (!legendValue) return shapeIfNoCategory

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -945,6 +945,27 @@ export const DataConfigurationModel = types
           default:
             return ''
         }
+      },
+      /*
+       * The shape for a case, mirroring getLegendColorForCase.
+       *
+       * Only categorical legends carry shapes. A numeric or date legend has no categories to assign
+       * one to, and a colour legend supplies its own colours; those all resolve to the default so
+       * every point in such a plot shares one shape. Callers pass the display's own shape as
+       * `shapeIfNoCategory`, which is what a plot with no legend attribute uses throughout.
+       */
+      getLegendShapeForCase(id: string, shapeIfNoCategory: PointShape = kDefaultPointShape): PointShape {
+        const legendID = self.attributeID('legend')
+        const legendAttribute = self.dataset?.getAttribute(legendID)
+        if (!id || !legendID || !legendAttribute) return shapeIfNoCategory
+
+        const legendType = self.attributeType('legend')
+        if (legendType !== 'categorical' && legendType !== 'checkbox') return shapeIfNoCategory
+
+        const legendValue = self.dataset?.getStrValue(id, legendID)
+        if (!legendValue) return shapeIfNoCategory
+
+        return self.getLegendShapeForCategory(legendValue)
       }
     }))
   .actions(self => ({

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -860,6 +860,24 @@ export const DataConfigurationModel = types
       casesInBinAreSelected(quantile: number): boolean {
         const selection = self.getCasesForLegendBin(quantile)
         return !!(selection.length > 0 && selection?.every((anID: string) => self.dataset?.isCaseSelected(anID)))
+      },
+      /*
+       * Whether the legend attribute lives in a collection more childmost than the plotted cases.
+       * A point then stands for several children at once, and resolving the legend through any one
+       * of them would attribute that child's value to the whole group, so callers fall back.
+       *
+       * Lives a block above the two views that use it so they can reach it through `self`. They are
+       * routinely passed around as detached function references -- a plot hands
+       * `dataConfig.getLegendColorForCase` to setPointCoordinates, which calls it bare -- so `this`
+       * inside them is undefined and cannot be used to reach a sibling view.
+       */
+      get legendCollectionIsMoreChildmost(): boolean {
+        const legendID = self.attributeID('legend')
+        const legendCollectionID = self.dataset?.getCollectionForAttribute(legendID)?.id
+        const legendCollectionIndex = self.dataset?.getCollectionIndex(legendCollectionID) ?? 0
+        const childmostCollectionID = idOfChildmostCollectionForAttributes(self.axisAttributeIDs, self.dataset)
+        const childmostCollectionIndex = self.dataset?.getCollectionIndex(childmostCollectionID) ?? 0
+        return legendCollectionIndex > childmostCollectionIndex
       }
     }))
   .views(self => (
@@ -919,19 +937,6 @@ export const DataConfigurationModel = types
             return 0
         }
       },
-      /*
-       * Whether the legend attribute lives in a collection more childmost than the plotted cases.
-       * A point then stands for several children at once, and resolving the legend through any one
-       * of them would attribute that child's value to the whole group, so callers fall back.
-       */
-      get legendCollectionIsMoreChildmost(): boolean {
-        const legendID = self.attributeID('legend')
-        const legendCollectionID = self.dataset?.getCollectionForAttribute(legendID)?.id
-        const legendCollectionIndex = self.dataset?.getCollectionIndex(legendCollectionID) ?? 0
-        const childmostCollectionID = idOfChildmostCollectionForAttributes(self.axisAttributeIDs, self.dataset)
-        const childmostCollectionIndex = self.dataset?.getCollectionIndex(childmostCollectionID) ?? 0
-        return legendCollectionIndex > childmostCollectionIndex
-      },
       getLegendColorForCase(id: string, colorIfMissing = missingColor): string {
         const legendID = self.attributeID('legend')
         // todo: When user deletes we are not currently deleting the legend attribute ID. But we should.
@@ -940,7 +945,7 @@ export const DataConfigurationModel = types
           return ''
         }
         const legendType = self.attributeType('legend')
-        if (this.legendCollectionIsMoreChildmost) {
+        if (self.legendCollectionIsMoreChildmost) {
           return colorIfMissing
         }
         const legendValue = self.dataset?.getStrValue(id, legendID)
@@ -979,7 +984,7 @@ export const DataConfigurationModel = types
         if (legendType !== 'categorical' && legendType !== 'checkbox') return shapeIfNoCategory
 
         // as for color: a legend below the plotted cases cannot speak for a parent-level point
-        if (this.legendCollectionIsMoreChildmost) return shapeIfNoCategory
+        if (self.legendCollectionIsMoreChildmost) return shapeIfNoCategory
 
         const legendValue = self.dataset?.getStrValue(id, legendID)
         if (!legendValue) return shapeIfNoCategory

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -862,6 +862,15 @@ export const DataConfigurationModel = types
         return !!(selection.length > 0 && selection?.every((anID: string) => self.dataset?.isCaseSelected(anID)))
       },
       /*
+       * Whether the legend assigns per-category state. Note this is narrower than
+       * isCategoricalAttributeType, which counts a color legend too: that one gives each case a
+       * color of its own, so there are no categories to hang a color or a shape on.
+       */
+      get legendHasCategories(): boolean {
+        const legendType = self.attributeType('legend')
+        return legendType === 'categorical' || legendType === 'checkbox'
+      },
+      /*
        * Whether the legend attribute lives in a collection more childmost than the plotted cases.
        * A point then stands for several children at once, and resolving the legend through any one
        * of them would attribute that child's value to the whole group, so callers fall back.
@@ -912,8 +921,7 @@ export const DataConfigurationModel = types
       // Changes identity when any category's shape changes, so a display can react to it the way it
       // reacts to legendColorDomain.
       get legendShapeDomain() {
-        const legendType = self.attributeType('legend')
-        if (legendType !== 'categorical' && legendType !== 'checkbox') return undefined
+        if (!self.legendHasCategories) return undefined
         return self.categorySetForAttrRole('legend')?.shapeMap
       },
       get legendColorDomain() {
@@ -963,22 +971,15 @@ export const DataConfigurationModel = types
             return ''
         }
       },
-      /*
-       * The shape for a case, mirroring getLegendColorForCase.
-       *
-       * Only a categorical legend has categories to carry shapes, so every other kind resolves to
-       * `shapeIfNoCategory` -- the display's own shape, which is also what a plot with no legend
-       * attribute draws throughout.
-       */
+      // `shapeIfNoCategory` is the display's own shape, which is what a plot with no legend draws
+      // throughout.
       getLegendShapeForCase(id: string, shapeIfNoCategory: PointShape = kDefaultPointShape): PointShape {
         const legendID = self.attributeID('legend')
         const legendAttribute = self.dataset?.getAttribute(legendID)
         if (!id || !legendID || !legendAttribute) return shapeIfNoCategory
 
-        const legendType = self.attributeType('legend')
-        if (legendType !== 'categorical' && legendType !== 'checkbox') return shapeIfNoCategory
+        if (!self.legendHasCategories) return shapeIfNoCategory
 
-        // as for color: a legend below the plotted cases cannot speak for a parent-level point
         if (self.legendCollectionIsMoreChildmost) return shapeIfNoCategory
 
         const legendValue = self.dataset?.getStrValue(id, legendID)

--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -741,9 +741,11 @@ export const DataConfigurationModel = types
         return categorySet?.colorForCategory(cat) ?? missingColor
       },
 
-      getLegendShapeForCategory(cat: string): PointShape {
+      // `shapeIfUnset` is the display's own shape, so a category the user has not assigned one to
+      // keeps drawing whatever the plot drew before a legend was added.
+      getLegendShapeForCategory(cat: string, shapeIfUnset: PointShape = kDefaultPointShape): PointShape {
         const categorySet = self.categorySetForAttrRole('legend')
-        return categorySet?.shapeForCategory(cat) ?? kDefaultPointShape
+        return categorySet?.shapeForCategory(cat, shapeIfUnset) ?? shapeIfUnset
       },
 
       getLegendColorForNumericValue(value: number): string {
@@ -975,7 +977,7 @@ export const DataConfigurationModel = types
         const legendValue = self.dataset?.getStrValue(id, legendID)
         if (!legendValue) return shapeIfNoCategory
 
-        return self.getLegendShapeForCategory(legendValue)
+        return self.getLegendShapeForCategory(legendValue, shapeIfNoCategory)
       }
     }))
   .actions(self => ({

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.test.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.test.ts
@@ -47,6 +47,9 @@ describe("CanvasPointRenderer", () => {
       setTransform: jest.fn(),
       beginPath: jest.fn(),
       arc: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      closePath: jest.fn(),
       fill: jest.fn(),
       stroke: jest.fn(),
       fillRect: jest.fn(),
@@ -690,6 +693,48 @@ describe("CanvasPointRenderer", () => {
 
       expect(mockContext.arc).toHaveBeenCalled()
       expect(mockContext.fill).toHaveBeenCalled()
+    })
+
+    it("traces a polygon rather than an arc for a non-circle shape", () => {
+      /*
+       * The geometry module is unit-tested on its own, but nothing else proves it is wired into
+       * the draw path: delete the shape branch from the renderer and every geometry test still
+       * passes while the plot silently draws circles.
+       */
+      const caseData = createCaseData(0, "case1")
+      renderer.matchPointsToData("dataset1", [caseData], "points", { ...defaultStyle, shape: "square" })
+      const point = renderer.getPointForCaseData(caseData)!
+      renderer.setPointPosition(point, 100, 100)
+
+      renderer.startRendering()
+      flushRAF()
+
+      expect(mockContext.moveTo).toHaveBeenCalled()
+      expect(mockContext.lineTo).toHaveBeenCalled()
+      expect(mockContext.closePath).toHaveBeenCalled()
+      expect(mockContext.fill).toHaveBeenCalled()
+      // a square is not drawn with an arc
+      expect(mockContext.arc).not.toHaveBeenCalled()
+    })
+
+    it("traces one line per vertex of the shape it is given", () => {
+      // distinguishes the shapes from each other, not merely polygon from circle: a square has
+      // four vertices and a triangle three, so a hard-coded outline would fail one of these
+      const cases = [{ shape: "square" as const, vertices: 4 }, { shape: "triangle" as const, vertices: 3 }]
+      cases.forEach(({ shape, vertices }) => {
+        jest.clearAllMocks()
+        const caseData = createCaseData(0, `case-${shape}`)
+        renderer.matchPointsToData("dataset1", [caseData], "points", { ...defaultStyle, shape })
+        const point = renderer.getPointForCaseData(caseData)!
+        renderer.setPointPosition(point, 100, 100)
+
+        renderer.startRendering()
+        flushRAF()
+
+        // moveTo for the first vertex, lineTo for each of the rest
+        expect(mockContext.moveTo).toHaveBeenCalledTimes(1)
+        expect(mockContext.lineTo).toHaveBeenCalledTimes(vertices - 1)
+      })
     })
 
     it("draws rectangles for bars display type", () => {

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -585,7 +585,6 @@ export class CanvasPointRenderer extends PointRendererBase {
         this.ctx.strokeRect(rectX, rectY, width, height)
       }
     } else {
-      // Draw the point's shape, which is a circle unless the legend assigns another
       tracePointShape(this.ctx, style.shape ?? kDefaultPointShape, radius)
       this.ctx.fillStyle = fill
       this.ctx.fill()

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -49,7 +49,7 @@ interface ISubPlotClipRect {
  * Canvas 2D point renderer implementing the PointRendererBase interface.
  */
 /*
- * Traces a point's outline onto the context, centred on the current origin. Leaves the path open
+ * Traces a point's outline onto the context, centered on the current origin. Leaves the path open
  * for the caller to fill and stroke, so the two share one path rather than tracing it twice.
  */
 function tracePointShape(ctx: CanvasRenderingContext2D, shape: PointShape, radius: number) {

--- a/v3/src/components/data-display/renderer/canvas-point-renderer.ts
+++ b/v3/src/components/data-display/renderer/canvas-point-renderer.ts
@@ -10,6 +10,7 @@
  * Canvas 2D contexts are virtually unlimited.
  */
 
+import { kDefaultPointShape, PointShape } from "../../../utilities/point-shape-utils"
 import { CaseDataWithSubPlot } from "../d3-types"
 import { PointDisplayType, transitionDuration } from "../data-display-types"
 import { coalesceBars, IBarPiece, pointStateToBarPiece } from "./bar-coalescing"
@@ -19,6 +20,7 @@ import {
   getRendererForEvent,
   PointRendererBase
 } from "./point-renderer-base"
+import { pointShapeGeometry } from "./point-shapes"
 import { PointsState } from "./points-state"
 import {
   IBackgroundEventDistributionOptions,
@@ -46,6 +48,21 @@ interface ISubPlotClipRect {
 /**
  * Canvas 2D point renderer implementing the PointRendererBase interface.
  */
+/*
+ * Traces a point's outline onto the context, centred on the current origin. Leaves the path open
+ * for the caller to fill and stroke, so the two share one path rather than tracing it twice.
+ */
+function tracePointShape(ctx: CanvasRenderingContext2D, shape: PointShape, radius: number) {
+  const geometry = pointShapeGeometry(shape, radius)
+  ctx.beginPath()
+  if (geometry.kind === "circle") {
+    ctx.arc(0, 0, geometry.radius, 0, Math.PI * 2)
+    return
+  }
+  geometry.points.forEach(({ x, y }, i) => (i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y)))
+  ctx.closePath()
+}
+
 export class CanvasPointRenderer extends PointRendererBase {
   // Canvas elements
   private _canvas: HTMLCanvasElement | null = null
@@ -568,9 +585,8 @@ export class CanvasPointRenderer extends PointRendererBase {
         this.ctx.strokeRect(rectX, rectY, width, height)
       }
     } else {
-      // Draw circle (point)
-      this.ctx.beginPath()
-      this.ctx.arc(0, 0, radius, 0, Math.PI * 2)
+      // Draw the point's shape, which is a circle unless the legend assigns another
+      tracePointShape(this.ctx, style.shape ?? kDefaultPointShape, radius)
       this.ctx.fillStyle = fill
       this.ctx.fill()
 
@@ -578,6 +594,9 @@ export class CanvasPointRenderer extends PointRendererBase {
         this.ctx.strokeStyle = effectiveStroke
         this.ctx.lineWidth = strokeWidth / effectiveScale // Compensate for scale
         this.ctx.globalAlpha = strokeOpacity ?? 0.4
+        // Rounds the joins, without which the star's 36-degree points and the X's corners grow
+        // spikes at small radii under the default miter.
+        this.ctx.lineJoin = "round"
         this.ctx.stroke()
       }
     }

--- a/v3/src/components/data-display/renderer/canvas/canvas-hit-tester.test.ts
+++ b/v3/src/components/data-display/renderer/canvas/canvas-hit-tester.test.ts
@@ -1,4 +1,5 @@
 import { CanvasHitTester } from "./canvas-hit-tester"
+import { PointShape, PointShapes } from "../../../../utilities/point-shape-utils"
 import { IPointState, IPointStyle } from "../point-renderer-types"
 
 describe("CanvasHitTester", () => {
@@ -30,6 +31,92 @@ describe("CanvasHitTester", () => {
 
   const circleAnchor = { x: 0.5, y: 0.5 }
   const barAnchor = { x: 0, y: 1 }
+
+
+  describe("point shapes", () => {
+    const shapedPoint = (shape: PointShape, x: number, y: number) =>
+      createPointState("p1", x, y, { style: { ...defaultStyle, shape } })
+
+    it("responds to a click on a star's tip, which lies outside the point radius", () => {
+      // The tip reaches 1.42r, so a radius-sized hit area would leave the drawn ink dead.
+      const hitTester = new CanvasHitTester()
+      hitTester.updateFromPoints([shapedPoint("star", 100, 100)], "points", circleAnchor)
+
+      expect(hitTester.hitTest(100, 100 - 13)).toBe("p1")
+    })
+
+    it("responds to a click on a triangle's apex", () => {
+      /*
+       * The triangle is centered on its centroid, so the apex is further from the point than half
+       * the shape's width. Filing it in the grid by half its width put the apex in a cell the
+       * point was not listed under, and the click found nothing at all.
+       */
+      const hitTester = new CanvasHitTester()
+      hitTester.updateFromPoints([shapedPoint("triangle", 100, 100)], "points", circleAnchor)
+
+      expect(hitTester.hitTest(100, 100 - 14)).toBe("p1")
+    })
+
+    it("ignores a click in the gap between a star's arms", () => {
+      const hitTester = new CanvasHitTester()
+      hitTester.updateFromPoints([shapedPoint("star", 100, 100)], "points", circleAnchor)
+
+      // 13px out along an inner vertex, where the outline reaches under 7
+      const rad = -54 * Math.PI / 180
+      expect(hitTester.hitTest(100 + Math.cos(rad) * 13, 100 + Math.sin(rad) * 13)).toBeUndefined()
+    })
+
+    it("keeps every shape at least as easy to hit as a circle", () => {
+      PointShapes.forEach(shape => {
+        const hitTester = new CanvasHitTester()
+        hitTester.updateFromPoints([shapedPoint(shape, 100, 100)], "points", circleAnchor)
+
+        for (let deg = 0; deg < 360; deg += 15) {
+          const rad = deg * Math.PI / 180
+          const x = 100 + Math.cos(rad) * 9.9
+          const y = 100 + Math.sin(rad) * 9.9
+          expect(hitTester.hitTest(x, y)).toBe("p1")
+        }
+      })
+    })
+
+    it("files a shape in the grid by its reach, not by the point radius", () => {
+      /*
+       * At the default cell size the +/-1 cell margin hitTest already searches is far wider than
+       * any shape's overhang, so mis-filing a star is invisible. That is a property of the current
+       * tuning rather than of the code: the cell size is a constructor argument, and points scale
+       * with the size slider. Tuned here so the grid, not the margin, decides.
+       */
+      const hitTester = new CanvasHitTester(8)
+      const big = createPointState("p1", 200, 200, { style: { ...defaultStyle, radius: 40, shape: "star" } })
+      hitTester.updateFromPoints([big], "points", circleAnchor)
+
+      // the tip reaches 56.8; a grid filed by the radius alone stops at 40 and never offers it
+      expect(hitTester.hitTest(200, 200 - 54)).toBe("p1")
+    })
+
+    it("treats a point with no shape as a circle", () => {
+      // every style that predates shapes omits it, and those points must hit exactly as before
+      const hitTester = new CanvasHitTester()
+      hitTester.updateFromPoints([createPointState("p1", 100, 100)], "points", circleAnchor)
+
+      expect(hitTester.hitTest(100, 95)).toBe("p1")
+      expect(hitTester.hitTest(100, 100 - 13)).toBeUndefined()
+    })
+
+    it("hits the shape actually drawn rather than the one beside it", () => {
+      // a star's tip overlaps the cell of its neighbor, so the grid alone cannot decide
+      const hitTester = new CanvasHitTester()
+      hitTester.updateFromPoints([
+        shapedPoint("star", 100, 100),
+        createPointState("p2", 130, 100, { style: { ...defaultStyle, shape: "circle" } })
+      ], "points", circleAnchor)
+
+      expect(hitTester.hitTest(100, 100 - 13)).toBe("p1")
+      expect(hitTester.hitTest(130, 100)).toBe("p2")
+      expect(hitTester.hitTest(115, 100)).toBeUndefined()
+    })
+  })
 
   describe("construction", () => {
     it("creates hit tester with default cell size", () => {

--- a/v3/src/components/data-display/renderer/canvas/canvas-hit-tester.ts
+++ b/v3/src/components/data-display/renderer/canvas/canvas-hit-tester.ts
@@ -5,8 +5,10 @@
  * The grid is rebuilt after each render from current point positions.
  */
 
+import { kDefaultPointShape, PointShape } from "../../../../utilities/point-shape-utils"
 import { PointDisplayType } from "../../data-display-types"
 import { anchoredBarRect } from "../bar-coalescing"
+import { isPointInShape, pointShapeBoundingRadius } from "../point-shapes"
 import { IPointState } from "../point-renderer-types"
 
 /**
@@ -28,12 +30,14 @@ interface IHitTestBounds {
   y: number
   width: number
   height: number
-  /** For circles: center x */
+  /** For points: center x */
   centerX?: number
-  /** For circles: center y */
+  /** For points: center y */
   centerY?: number
-  /** For circles: radius (for precise circle hit testing) */
+  /** For points: the point radius (for precise hit testing; not the box, which a shape may exceed) */
   radius?: number
+  /** For points: the drawn shape, tested against directly */
+  shape?: PointShape
 }
 
 /**
@@ -176,16 +180,21 @@ export class CanvasHitTester {
       const { left, top, width, height } = anchoredBarRect(x, y, style.width, style.height, scale, anchor)
       return { x: left, y: top, width, height }
     } else {
-      // Circle/point
+      // Point. The box has to cover the drawn shape, which for everything but a circle reaches
+      // further than the radius, or a star's tips would fall in grid cells the point is not filed
+      // under and a click on one would find nothing.
       const r = style.radius * scale
+      const shape = style.shape ?? kDefaultPointShape
+      const reach = pointShapeBoundingRadius(shape, r)
       return {
-        x: x - r,
-        y: y - r,
-        width: r * 2,
-        height: r * 2,
+        x: x - reach,
+        y: y - reach,
+        width: reach * 2,
+        height: reach * 2,
         centerX: x,
         centerY: y,
-        radius: r
+        radius: r,
+        shape
       }
     }
   }
@@ -218,11 +227,10 @@ export class CanvasHitTester {
   }
 
   private containsPoint(bounds: IHitTestBounds, px: number, py: number): boolean {
-    // For circles, use precise distance check
+    // For points, test the drawn shape rather than the box the grid files it under
     if (bounds.radius !== undefined && bounds.centerX !== undefined && bounds.centerY !== undefined) {
-      const dx = px - bounds.centerX
-      const dy = py - bounds.centerY
-      return (dx * dx + dy * dy) <= (bounds.radius * bounds.radius)
+      return isPointInShape(bounds.shape ?? kDefaultPointShape, bounds.radius,
+                            px - bounds.centerX, py - bounds.centerY)
     }
 
     // For rectangles, use bounding box

--- a/v3/src/components/data-display/renderer/point-renderer-types.ts
+++ b/v3/src/components/data-display/renderer/point-renderer-types.ts
@@ -15,8 +15,6 @@ export interface IPoint {
  */
 export interface IPointStyle {
   radius: number
-  // Absent means the default. Optional so every existing caller that builds a style keeps working
-  // and keeps drawing circles.
   shape?: PointShape
   fill: string
   stroke: string

--- a/v3/src/components/data-display/renderer/point-renderer-types.ts
+++ b/v3/src/components/data-display/renderer/point-renderer-types.ts
@@ -1,5 +1,6 @@
 import { CaseData, CaseDataWithSubPlot } from "../d3-types"
 import { PointDisplayType } from "../data-display-types"
+import { PointShape } from "../../../utilities/point-shape-utils"
 
 /**
  * Opaque point handle - consumers don't need to know the underlying implementation
@@ -14,6 +15,9 @@ export interface IPoint {
  */
 export interface IPointStyle {
   radius: number
+  // Absent means the default. Optional so every existing caller that builds a style keeps working
+  // and keeps drawing circles.
+  shape?: PointShape
   fill: string
   stroke: string
   strokeWidth: number

--- a/v3/src/components/data-display/renderer/point-shapes.test.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.test.ts
@@ -1,8 +1,9 @@
 import { PointShapes } from "../../../utilities/point-shape-utils"
 import {
-  IShapePoint, isPointInShape, pointShapeArea, pointShapeBoundingRadius, pointShapeExtent,
+  isPointInShape, pointShapeArea, pointShapeBoundingRadius, pointShapeExtent,
   pointShapeGeometry
 } from "./point-shapes"
+import { Point } from "../data-display-types"
 
 /*
  * The reference table from the design prototype's ASSET-SPEC.md, evaluated at r = 8. These are the
@@ -20,7 +21,7 @@ const kReferenceAtR8 = {
 
 // Area of a closed polygon by the shoelace formula, so the declared area is checked against the
 // vertices actually drawn rather than against itself.
-function polygonArea(points: IShapePoint[]) {
+function polygonArea(points: Point[]) {
   let sum = 0
   for (let i = 0; i < points.length; i++) {
     const a = points[i]
@@ -31,7 +32,7 @@ function polygonArea(points: IShapePoint[]) {
 }
 
 // Area-weighted centroid, also by the shoelace formula.
-function polygonCentroid(points: IShapePoint[]) {
+function polygonCentroid(points: Point[]) {
   let a = 0, cx = 0, cy = 0
   for (let i = 0; i < points.length; i++) {
     const p = points[i]
@@ -45,21 +46,26 @@ function polygonCentroid(points: IShapePoint[]) {
   return { x: cx / (6 * a), y: cy / (6 * a) }
 }
 
-function polygonExtent(points: IShapePoint[]) {
+function polygonExtent(points: Point[]) {
   const xs = points.map(p => p.x)
   const ys = points.map(p => p.y)
   return { w: Math.max(...xs) - Math.min(...xs), h: Math.max(...ys) - Math.min(...ys) }
 }
 
+// the reference radius the assertions are written against
+const kR = 8
+const kSmallR = 3
+const kLargeR = 12
+
 describe("point shape geometry", () => {
   it("covers every shape", () => {
     PointShapes.forEach(shape => {
-      expect(pointShapeGeometry(shape, 8)).toBeDefined()
+      expect(pointShapeGeometry(shape, kR)).toBeDefined()
     })
   })
 
-  it("draws the circle as an arc of exactly r, unchanged from what CODAP already ships", () => {
-    const geometry = pointShapeGeometry("circle", 8)
+  it("draws the circle as an arc of exactly kR, unchanged from what CODAP already ships", () => {
+    const geometry = pointShapeGeometry("circle", kR)
     expect(geometry).toEqual({ kind: "circle", radius: 8 })
     // no polygonal approximation: that would change how the existing shape rasterizes
     expect(geometry.kind).not.toBe("polygon")
@@ -67,7 +73,7 @@ describe("point shape geometry", () => {
 
   it("draws every other shape as a polygon", () => {
     PointShapes.filter(s => s !== "circle").forEach(shape => {
-      const geometry = pointShapeGeometry(shape, 8)
+      const geometry = pointShapeGeometry(shape, kR)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       expect(geometry.points.length).toBeGreaterThanOrEqual(3)
     })
@@ -78,8 +84,8 @@ describe("point shape geometry", () => {
       const expected = kReferenceAtR8[shape]
 
       it(`${shape}`, () => {
-        expect(pointShapeArea(shape, 8)).toBeCloseTo(expected.area, 1)
-        const extent = pointShapeExtent(shape, 8)
+        expect(pointShapeArea(shape, kR)).toBeCloseTo(expected.area, 1)
+        const extent = pointShapeExtent(shape, kR)
         expect(extent.w).toBeCloseTo(expected.w, 2)
         expect(extent.h).toBeCloseTo(expected.h, 2)
       })
@@ -89,9 +95,9 @@ describe("point shape geometry", () => {
   it("normalizes every non-circular shape to about 90% of the circle's area", () => {
     // Equal area is deliberately not the target: straight edges and points read heavier than a
     // circle of identical ink.
-    const circleArea = pointShapeArea("circle", 8)
+    const circleArea = pointShapeArea("circle", kR)
     PointShapes.filter(s => s !== "circle").forEach(shape => {
-      const pct = 100 * pointShapeArea(shape, 8) / circleArea
+      const pct = 100 * pointShapeArea(shape, kR) / circleArea
       expect(pct).toBeGreaterThanOrEqual(89)
       expect(pct).toBeLessThanOrEqual(93)
     })
@@ -101,18 +107,18 @@ describe("point shape geometry", () => {
     // Guards the two from drifting apart: the declared area is a closed form, the drawn area comes
     // from the vertex list.
     PointShapes.filter(s => s !== "circle").forEach(shape => {
-      const geometry = pointShapeGeometry(shape, 8)
+      const geometry = pointShapeGeometry(shape, kR)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
-      expect(polygonArea(geometry.points)).toBeCloseTo(pointShapeArea(shape, 8), 1)
+      expect(polygonArea(geometry.points)).toBeCloseTo(pointShapeArea(shape, kR), 1)
     })
   })
 
   it("declares an extent that matches the vertices it actually draws", () => {
     PointShapes.filter(s => s !== "circle").forEach(shape => {
-      const geometry = pointShapeGeometry(shape, 8)
+      const geometry = pointShapeGeometry(shape, kR)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       const drawn = polygonExtent(geometry.points)
-      const declared = pointShapeExtent(shape, 8)
+      const declared = pointShapeExtent(shape, kR)
       expect(drawn.w).toBeCloseTo(declared.w, 2)
       expect(drawn.h).toBeCloseTo(declared.h, 2)
     })
@@ -125,7 +131,7 @@ describe("point shape geometry", () => {
      * downward jump when a category is switched to it.
      */
     PointShapes.filter(s => s !== "circle").forEach(shape => {
-      const geometry = pointShapeGeometry(shape, 8)
+      const geometry = pointShapeGeometry(shape, kR)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       const centroid = polygonCentroid(geometry.points)
       expect(centroid.x).toBeCloseTo(0, 6)
@@ -139,7 +145,7 @@ describe("point shape geometry", () => {
     // the shape is symmetric about its position.
     const offCenter = ["triangle", "star"] as const
     offCenter.forEach(shape => {
-      const geometry = pointShapeGeometry(shape, 8)
+      const geometry = pointShapeGeometry(shape, kR)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       const ys = geometry.points.map(p => p.y)
       expect((Math.max(...ys) + Math.min(...ys)) / 2).not.toBeCloseTo(0, 2)
@@ -147,7 +153,7 @@ describe("point shape geometry", () => {
 
     // and every other shape is symmetric, so its box center and centroid agree
     PointShapes.filter(s => s !== "circle" && !offCenter.includes(s as any)).forEach(shape => {
-      const geometry = pointShapeGeometry(shape, 8)
+      const geometry = pointShapeGeometry(shape, kR)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       const ys = geometry.points.map(p => p.y)
       expect((Math.max(...ys) + Math.min(...ys)) / 2).toBeCloseTo(0, 6)
@@ -158,58 +164,45 @@ describe("point shape geometry", () => {
     // Point size is a continuous multiplier, so the shapes have to hold their proportions across
     // the whole range rather than only at the reference radius.
     PointShapes.forEach(shape => {
-      const smallExtent = pointShapeExtent(shape, 3)
-      const largeExtent = pointShapeExtent(shape, 12)
+      const smallExtent = pointShapeExtent(shape, kSmallR)
+      const largeExtent = pointShapeExtent(shape, kLargeR)
       expect(largeExtent.w / smallExtent.w).toBeCloseTo(4, 6)
       expect(largeExtent.h / smallExtent.h).toBeCloseTo(4, 6)
       // area goes with the square of the radius
-      expect(pointShapeArea(shape, 12) / pointShapeArea(shape, 3)).toBeCloseTo(16, 6)
+      expect(pointShapeArea(shape, kLargeR) / pointShapeArea(shape, kSmallR)).toBeCloseTo(16, 6)
     })
   })
 
   it("gives X the same ink as Plus, being the same outline rotated", () => {
-    expect(pointShapeArea("x", 8)).toBeCloseTo(pointShapeArea("plus", 8), 6)
+    expect(pointShapeArea("x", kR)).toBeCloseTo(pointShapeArea("plus", kR), 6)
   })
 
   describe("bounding radius", () => {
-    it("reaches the furthest drawn point, which is not r for anything but the circle", () => {
-      expect(pointShapeBoundingRadius("circle", 8)).toBeCloseTo(8, 6)
-      // a star is drawn well outside a radius-8 circle, which is why hit testing cannot use r
-      expect(pointShapeBoundingRadius("star", 8)).toBeGreaterThan(10)
-    })
+    it("reaches the furthest drawn point of every shape", () => {
+      expect(pointShapeBoundingRadius("circle", kR)).toBeCloseTo(kR, 6)
 
-    it("reaches every vertex of every shape", () => {
-      /*
-       * Asserted against the vertices rather than the extent. The extent is the size of the drawn
-       * box and cannot see where that box sits, so comparing against half of it is satisfied by any
-       * value big enough for a symmetric shape while still falling short on an asymmetric one.
-       */
-      PointShapes.filter(s => s !== "circle").forEach(shape => {
-        const geometry = pointShapeGeometry(shape, 8)
+      PointShapes.filter(sh => sh !== "circle").forEach(shape => {
+        const geometry = pointShapeGeometry(shape, kR)
         if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
-        const furthest = Math.max(...geometry.points.map(p => Math.hypot(p.x, p.y)))
-        expect(pointShapeBoundingRadius(shape, 8)).toBeGreaterThanOrEqual(furthest - 1e-9)
+        const furthest = Math.max(...geometry.points.map(pt => Math.hypot(pt.x, pt.y)))
+        expect(pointShapeBoundingRadius(shape, kR)).toBeGreaterThanOrEqual(furthest - 1e-9)
       })
     })
 
-    it("reaches the triangle's apex, which is further out than half its width", () => {
-      // The triangle is centered on its centroid, so its box hangs low and half its width stops
-      // short of the apex. A hit area sized that way does not respond to a click on the apex.
-      const geometry = pointShapeGeometry("triangle", 8)
+    it("reaches past half the drawn box, where the box is off center", () => {
+      // why this is measured from the vertices rather than the extent: a triangle's box hangs low,
+      // so half its width stops short of the apex and a hit area sized that way misses it
+      const geometry = pointShapeGeometry("triangle", kR)
       if (geometry.kind !== "polygon") throw new Error("triangle should be a polygon")
-      const apex = geometry.points.reduce((a, p) => (p.y < a.y ? p : a))
-      const apexDistance = Math.hypot(apex.x, apex.y)
+      const apex = geometry.points.reduce((a, pt) => (pt.y < a.y ? pt : a))
 
-      expect(apexDistance).toBeGreaterThan(pointShapeExtent("triangle", 8).w / 2)
-      expect(pointShapeBoundingRadius("triangle", 8)).toBeGreaterThanOrEqual(apexDistance - 1e-9)
+      expect(Math.hypot(apex.x, apex.y)).toBeGreaterThan(pointShapeExtent("triangle", kR).w / 2)
     })
   })
 
   describe("containment", () => {
-    const r = 8
-
     it("puts the center of every shape inside it", () => {
-      PointShapes.forEach(shape => expect(isPointInShape(shape, r, 0, 0)).toBe(true))
+      PointShapes.forEach(shape => expect(isPointInShape(shape, kR, 0, 0)).toBe(true))
     })
 
     it("never makes a shape harder to hit than the circle it replaced", () => {
@@ -221,34 +214,34 @@ describe("point shape geometry", () => {
       PointShapes.forEach(shape => {
         for (let deg = 0; deg < 360; deg += 15) {
           const rad = deg * Math.PI / 180
-          const d = r * 0.99
-          expect(isPointInShape(shape, r, Math.cos(rad) * d, Math.sin(rad) * d)).toBe(true)
+          const d = kR * 0.99
+          expect(isPointInShape(shape, kR, Math.cos(rad) * d, Math.sin(rad) * d)).toBe(true)
         }
       })
     })
 
     it("includes the ink that reaches past the circle", () => {
-      // each of these is beyond r, so it is the outline rather than the circle answering
+      // each of these is beyond kR, so it is the outline rather than the circle answering
       // a star's tip points straight up
-      expect(isPointInShape("star", r, 0, -1.3 * r)).toBe(true)
+      expect(isPointInShape("star", kR, 0, -1.3 * kR)).toBe(true)
       // a square's corner
-      expect(isPointInShape("square", r, 0.8 * r, 0.8 * r)).toBe(true)
+      expect(isPointInShape("square", kR, 0.8 * kR, 0.8 * kR)).toBe(true)
       // a triangle's apex
-      expect(isPointInShape("triangle", r, 0, -1.4 * r)).toBe(true)
+      expect(isPointInShape("triangle", kR, 0, -1.4 * kR)).toBe(true)
     })
 
     it("excludes the gaps between a star's arms", () => {
       // 1.3r along the direction of an inner vertex, which the outline reaches only to 0.68r
       const rad = -54 * Math.PI / 180
-      expect(isPointInShape("star", r, Math.cos(rad) * 1.3 * r, Math.sin(rad) * 1.3 * r)).toBe(false)
+      expect(isPointInShape("star", kR, Math.cos(rad) * 1.3 * kR, Math.sin(rad) * 1.3 * kR)).toBe(false)
     })
 
     it("excludes everything beyond the shape", () => {
       PointShapes.forEach(shape => {
-        const beyond = pointShapeBoundingRadius(shape, r) + 0.01
+        const beyond = pointShapeBoundingRadius(shape, kR) + 0.01
         for (let deg = 0; deg < 360; deg += 15) {
           const rad = deg * Math.PI / 180
-          expect(isPointInShape(shape, r, Math.cos(rad) * beyond, Math.sin(rad) * beyond)).toBe(false)
+          expect(isPointInShape(shape, kR, Math.cos(rad) * beyond, Math.sin(rad) * beyond)).toBe(false)
         }
       })
     })

--- a/v3/src/components/data-display/renderer/point-shapes.test.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.test.ts
@@ -1,0 +1,168 @@
+import { PointShapes } from "../../../utilities/point-shape-utils"
+import {
+  IShapePoint, pointShapeArea, pointShapeBoundingRadius, pointShapeExtent, pointShapeGeometry
+} from "./point-shapes"
+
+/*
+ * The reference table from the design prototype's ASSET-SPEC.md, evaluated at r = 8. These are the
+ * numbers the tuned constants are supposed to produce; if a constant is edited, one of these fails.
+ */
+const kReferenceAtR8 = {
+  circle: { area: 201.1, pctOfCircle: 100.0, w: 16.00, h: 16.00 },
+  square: { area: 185.0, pctOfCircle: 92.0, w: 13.60, h: 13.60 },
+  triangle: { area: 180.2, pctOfCircle: 89.6, w: 20.40, h: 17.67 },
+  diamond: { area: 184.3, pctOfCircle: 91.7, w: 19.20, h: 19.20 },
+  star: { area: 182.0, pctOfCircle: 90.5, w: 21.61, h: 20.55 },
+  plus: { area: 183.7, pctOfCircle: 91.4, w: 17.28, h: 17.28 },
+  x: { area: 183.7, pctOfCircle: 91.4, w: 16.86, h: 16.86 }
+} as const
+
+// Area of a closed polygon by the shoelace formula, so the declared area is checked against the
+// vertices actually drawn rather than against itself.
+function polygonArea(points: IShapePoint[]) {
+  let sum = 0
+  for (let i = 0; i < points.length; i++) {
+    const a = points[i]
+    const b = points[(i + 1) % points.length]
+    sum += a.x * b.y - b.x * a.y
+  }
+  return Math.abs(sum) / 2
+}
+
+function polygonExtent(points: IShapePoint[]) {
+  const xs = points.map(p => p.x)
+  const ys = points.map(p => p.y)
+  return { w: Math.max(...xs) - Math.min(...xs), h: Math.max(...ys) - Math.min(...ys) }
+}
+
+describe("point shape geometry", () => {
+  it("covers every shape", () => {
+    PointShapes.forEach(shape => {
+      expect(pointShapeGeometry(shape, 8)).toBeDefined()
+    })
+  })
+
+  it("draws the circle as an arc of exactly r, unchanged from what CODAP already ships", () => {
+    const geometry = pointShapeGeometry("circle", 8)
+    expect(geometry).toEqual({ kind: "circle", radius: 8 })
+    // no polygonal approximation: that would change how the existing shape rasterizes
+    expect(geometry.kind).not.toBe("polygon")
+  })
+
+  it("draws every other shape as a polygon", () => {
+    PointShapes.filter(s => s !== "circle").forEach(shape => {
+      const geometry = pointShapeGeometry(shape, 8)
+      if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
+      expect(geometry.points.length).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe("matches the reference metrics at r = 8", () => {
+    PointShapes.forEach(shape => {
+      const expected = kReferenceAtR8[shape]
+
+      it(`${shape}`, () => {
+        expect(pointShapeArea(shape, 8)).toBeCloseTo(expected.area, 1)
+        const extent = pointShapeExtent(shape, 8)
+        expect(extent.w).toBeCloseTo(expected.w, 2)
+        expect(extent.h).toBeCloseTo(expected.h, 2)
+      })
+    })
+  })
+
+  it("normalizes every non-circular shape to about 90% of the circle's area", () => {
+    // Equal area is deliberately not the target: straight edges and points read heavier than a
+    // circle of identical ink.
+    const circleArea = pointShapeArea("circle", 8)
+    PointShapes.filter(s => s !== "circle").forEach(shape => {
+      const pct = 100 * pointShapeArea(shape, 8) / circleArea
+      expect(pct).toBeGreaterThanOrEqual(89)
+      expect(pct).toBeLessThanOrEqual(93)
+    })
+  })
+
+  it("declares an area that matches the vertices it actually draws", () => {
+    // Guards the two from drifting apart: the declared area is a closed form, the drawn area comes
+    // from the vertex list.
+    PointShapes.filter(s => s !== "circle").forEach(shape => {
+      const geometry = pointShapeGeometry(shape, 8)
+      if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
+      expect(polygonArea(geometry.points)).toBeCloseTo(pointShapeArea(shape, 8), 1)
+    })
+  })
+
+  it("declares an extent that matches the vertices it actually draws", () => {
+    PointShapes.filter(s => s !== "circle").forEach(shape => {
+      const geometry = pointShapeGeometry(shape, 8)
+      if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
+      const drawn = polygonExtent(geometry.points)
+      const declared = pointShapeExtent(shape, 8)
+      expect(drawn.w).toBeCloseTo(declared.w, 2)
+      expect(drawn.h).toBeCloseTo(declared.h, 2)
+    })
+  })
+
+  it("centers every shape horizontally on the origin", () => {
+    PointShapes.filter(s => s !== "circle").forEach(shape => {
+      const geometry = pointShapeGeometry(shape, 8)
+      if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
+      const xs = geometry.points.map(p => p.x)
+      expect((Math.max(...xs) + Math.min(...xs)) / 2).toBeCloseTo(0, 6)
+    })
+  })
+
+  it("centers every shape but the star vertically too", () => {
+    /*
+     * The star is centered on its circumcircle rather than its bounding box: with a vertex at the
+     * top it reaches -R upward but only R*cos(36) down, so its box sits slightly low. That is how
+     * a star is conventionally drawn, and it is what the prototype does. The triangle, by contrast,
+     * is deliberately box-centered so it shares a visual baseline with the square.
+     */
+    PointShapes.filter(s => s !== "circle" && s !== "star").forEach(shape => {
+      const geometry = pointShapeGeometry(shape, 8)
+      if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
+      const ys = geometry.points.map(p => p.y)
+      expect((Math.max(...ys) + Math.min(...ys)) / 2).toBeCloseTo(0, 6)
+    })
+
+    const star = pointShapeGeometry("star", 8)
+    if (star.kind !== "polygon") throw new Error("star should be a polygon")
+    const starYs = star.points.map(p => p.y)
+    // the top vertex sits on the circumcircle, so the outline reaches exactly -R
+    expect(Math.min(...starYs)).toBeCloseTo(-1.420 * 8, 6)
+  })
+
+  it("scales linearly with the radius", () => {
+    // Point size is a continuous multiplier, so the shapes have to hold their proportions across
+    // the whole range rather than only at the reference radius.
+    PointShapes.forEach(shape => {
+      const smallExtent = pointShapeExtent(shape, 3)
+      const largeExtent = pointShapeExtent(shape, 12)
+      expect(largeExtent.w / smallExtent.w).toBeCloseTo(4, 6)
+      expect(largeExtent.h / smallExtent.h).toBeCloseTo(4, 6)
+      // area goes with the square of the radius
+      expect(pointShapeArea(shape, 12) / pointShapeArea(shape, 3)).toBeCloseTo(16, 6)
+    })
+  })
+
+  it("gives X the same ink as Plus, being the same outline rotated", () => {
+    expect(pointShapeArea("x", 8)).toBeCloseTo(pointShapeArea("plus", 8), 6)
+  })
+
+  describe("bounding radius", () => {
+    it("reaches the furthest drawn point, which is not r for anything but the circle", () => {
+      expect(pointShapeBoundingRadius("circle", 8)).toBeCloseTo(8, 6)
+      // a star is drawn well outside a radius-8 circle, which is why hit testing cannot use r
+      expect(pointShapeBoundingRadius("star", 8)).toBeGreaterThan(10)
+    })
+
+    it("covers the drawn extent of every shape", () => {
+      PointShapes.forEach(shape => {
+        const { w, h } = pointShapeExtent(shape, 8)
+        const radius = pointShapeBoundingRadius(shape, 8)
+        expect(radius).toBeGreaterThanOrEqual(w / 2 - 1e-9)
+        expect(radius).toBeGreaterThanOrEqual(h / 2 - 1e-9)
+      })
+    })
+  })
+})

--- a/v3/src/components/data-display/renderer/point-shapes.test.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.test.ts
@@ -1,6 +1,7 @@
 import { PointShapes } from "../../../utilities/point-shape-utils"
 import {
-  IShapePoint, pointShapeArea, pointShapeBoundingRadius, pointShapeExtent, pointShapeGeometry
+  IShapePoint, isPointInShape, pointShapeArea, pointShapeBoundingRadius, pointShapeExtent,
+  pointShapeGeometry
 } from "./point-shapes"
 
 /*
@@ -136,8 +137,8 @@ describe("point shape geometry", () => {
     // A consequence of the above, not a defect: for the triangle and the star the box center is
     // not the centroid. Anything deriving a hit area must use the drawn box rather than assume
     // the shape is symmetric about its position.
-    const offCentre = ["triangle", "star"] as const
-    offCentre.forEach(shape => {
+    const offCenter = ["triangle", "star"] as const
+    offCenter.forEach(shape => {
       const geometry = pointShapeGeometry(shape, 8)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       const ys = geometry.points.map(p => p.y)
@@ -145,7 +146,7 @@ describe("point shape geometry", () => {
     })
 
     // and every other shape is symmetric, so its box center and centroid agree
-    PointShapes.filter(s => s !== "circle" && !offCentre.includes(s as any)).forEach(shape => {
+    PointShapes.filter(s => s !== "circle" && !offCenter.includes(s as any)).forEach(shape => {
       const geometry = pointShapeGeometry(shape, 8)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       const ys = geometry.points.map(p => p.y)
@@ -177,13 +178,85 @@ describe("point shape geometry", () => {
       expect(pointShapeBoundingRadius("star", 8)).toBeGreaterThan(10)
     })
 
-    it("covers the drawn extent of every shape", () => {
-      PointShapes.forEach(shape => {
-        const { w, h } = pointShapeExtent(shape, 8)
-        const radius = pointShapeBoundingRadius(shape, 8)
-        expect(radius).toBeGreaterThanOrEqual(w / 2 - 1e-9)
-        expect(radius).toBeGreaterThanOrEqual(h / 2 - 1e-9)
+    it("reaches every vertex of every shape", () => {
+      /*
+       * Asserted against the vertices rather than the extent. The extent is the size of the drawn
+       * box and cannot see where that box sits, so comparing against half of it is satisfied by any
+       * value big enough for a symmetric shape while still falling short on an asymmetric one.
+       */
+      PointShapes.filter(s => s !== "circle").forEach(shape => {
+        const geometry = pointShapeGeometry(shape, 8)
+        if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
+        const furthest = Math.max(...geometry.points.map(p => Math.hypot(p.x, p.y)))
+        expect(pointShapeBoundingRadius(shape, 8)).toBeGreaterThanOrEqual(furthest - 1e-9)
       })
+    })
+
+    it("reaches the triangle's apex, which is further out than half its width", () => {
+      // The triangle is centered on its centroid, so its box hangs low and half its width stops
+      // short of the apex. A hit area sized that way does not respond to a click on the apex.
+      const geometry = pointShapeGeometry("triangle", 8)
+      if (geometry.kind !== "polygon") throw new Error("triangle should be a polygon")
+      const apex = geometry.points.reduce((a, p) => (p.y < a.y ? p : a))
+      const apexDistance = Math.hypot(apex.x, apex.y)
+
+      expect(apexDistance).toBeGreaterThan(pointShapeExtent("triangle", 8).w / 2)
+      expect(pointShapeBoundingRadius("triangle", 8)).toBeGreaterThanOrEqual(apexDistance - 1e-9)
+    })
+  })
+
+  describe("containment", () => {
+    const r = 8
+
+    it("puts the center of every shape inside it", () => {
+      PointShapes.forEach(shape => expect(isPointInShape(shape, r, 0, 0)).toBe(true))
+    })
+
+    it("never makes a shape harder to hit than the circle it replaced", () => {
+      /*
+       * The guarantee that lets shape be a free choice: a plus is narrower than a circle across its
+       * notches and a star is narrower between its arms, so testing the ink alone would shrink the
+       * target for anyone who picked one.
+       */
+      PointShapes.forEach(shape => {
+        for (let deg = 0; deg < 360; deg += 15) {
+          const rad = deg * Math.PI / 180
+          const d = r * 0.99
+          expect(isPointInShape(shape, r, Math.cos(rad) * d, Math.sin(rad) * d)).toBe(true)
+        }
+      })
+    })
+
+    it("includes the ink that reaches past the circle", () => {
+      // each of these is beyond r, so it is the outline rather than the circle answering
+      // a star's tip points straight up
+      expect(isPointInShape("star", r, 0, -1.3 * r)).toBe(true)
+      // a square's corner
+      expect(isPointInShape("square", r, 0.8 * r, 0.8 * r)).toBe(true)
+      // a triangle's apex
+      expect(isPointInShape("triangle", r, 0, -1.4 * r)).toBe(true)
+    })
+
+    it("excludes the gaps between a star's arms", () => {
+      // 1.3r along the direction of an inner vertex, which the outline reaches only to 0.68r
+      const rad = -54 * Math.PI / 180
+      expect(isPointInShape("star", r, Math.cos(rad) * 1.3 * r, Math.sin(rad) * 1.3 * r)).toBe(false)
+    })
+
+    it("excludes everything beyond the shape", () => {
+      PointShapes.forEach(shape => {
+        const beyond = pointShapeBoundingRadius(shape, r) + 0.01
+        for (let deg = 0; deg < 360; deg += 15) {
+          const rad = deg * Math.PI / 180
+          expect(isPointInShape(shape, r, Math.cos(rad) * beyond, Math.sin(rad) * beyond)).toBe(false)
+        }
+      })
+    })
+
+    it("scales with the radius", () => {
+      // a click that lands on a star's tip at r = 16 lands outside it at r = 4
+      expect(isPointInShape("star", 16, 0, -1.3 * 16)).toBe(true)
+      expect(isPointInShape("star", 4, 0, -1.3 * 16)).toBe(false)
     })
   })
 })

--- a/v3/src/components/data-display/renderer/point-shapes.test.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.test.ts
@@ -117,10 +117,10 @@ describe("point shape geometry", () => {
     })
   })
 
-  it("centres every shape on its centre of area", () => {
+  it("centers every shape on its center of area", () => {
     /*
      * The invariant that matters: a point drawn at a position must not read as sitting off it. An
-     * equilateral triangle centred on its bounding box instead sits h/6 low, which is visible as a
+     * equilateral triangle centered on its bounding box instead sits h/6 low, which is visible as a
      * downward jump when a category is switched to it.
      */
     PointShapes.filter(s => s !== "circle").forEach(shape => {
@@ -132,8 +132,8 @@ describe("point shape geometry", () => {
     })
   })
 
-  it("leaves the bounding box off centre where centring the ink requires it", () => {
-    // A consequence of the above, not a defect: for the triangle and the star the box centre is
+  it("leaves the bounding box off center where centering the ink requires it", () => {
+    // A consequence of the above, not a defect: for the triangle and the star the box center is
     // not the centroid. Anything deriving a hit area must use the drawn box rather than assume
     // the shape is symmetric about its position.
     const offCentre = ["triangle", "star"] as const
@@ -144,7 +144,7 @@ describe("point shape geometry", () => {
       expect((Math.max(...ys) + Math.min(...ys)) / 2).not.toBeCloseTo(0, 2)
     })
 
-    // and every other shape is symmetric, so its box centre and centroid agree
+    // and every other shape is symmetric, so its box center and centroid agree
     PointShapes.filter(s => s !== "circle" && !offCentre.includes(s as any)).forEach(shape => {
       const geometry = pointShapeGeometry(shape, 8)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)

--- a/v3/src/components/data-display/renderer/point-shapes.test.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.test.ts
@@ -29,6 +29,21 @@ function polygonArea(points: IShapePoint[]) {
   return Math.abs(sum) / 2
 }
 
+// Area-weighted centroid, also by the shoelace formula.
+function polygonCentroid(points: IShapePoint[]) {
+  let a = 0, cx = 0, cy = 0
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i]
+    const q = points[(i + 1) % points.length]
+    const cross = p.x * q.y - q.x * p.y
+    a += cross
+    cx += (p.x + q.x) * cross
+    cy += (p.y + q.y) * cross
+  }
+  a /= 2
+  return { x: cx / (6 * a), y: cy / (6 * a) }
+}
+
 function polygonExtent(points: IShapePoint[]) {
   const xs = points.map(p => p.x)
   const ys = points.map(p => p.y)
@@ -102,34 +117,40 @@ describe("point shape geometry", () => {
     })
   })
 
-  it("centers every shape horizontally on the origin", () => {
+  it("centres every shape on its centre of area", () => {
+    /*
+     * The invariant that matters: a point drawn at a position must not read as sitting off it. An
+     * equilateral triangle centred on its bounding box instead sits h/6 low, which is visible as a
+     * downward jump when a category is switched to it.
+     */
     PointShapes.filter(s => s !== "circle").forEach(shape => {
       const geometry = pointShapeGeometry(shape, 8)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
-      const xs = geometry.points.map(p => p.x)
-      expect((Math.max(...xs) + Math.min(...xs)) / 2).toBeCloseTo(0, 6)
+      const centroid = polygonCentroid(geometry.points)
+      expect(centroid.x).toBeCloseTo(0, 6)
+      expect(centroid.y).toBeCloseTo(0, 6)
     })
   })
 
-  it("centers every shape but the star vertically too", () => {
-    /*
-     * The star is centered on its circumcircle rather than its bounding box: with a vertex at the
-     * top it reaches -R upward but only R*cos(36) down, so its box sits slightly low. That is how
-     * a star is conventionally drawn, and it is what the prototype does. The triangle, by contrast,
-     * is deliberately box-centered so it shares a visual baseline with the square.
-     */
-    PointShapes.filter(s => s !== "circle" && s !== "star").forEach(shape => {
+  it("leaves the bounding box off centre where centring the ink requires it", () => {
+    // A consequence of the above, not a defect: for the triangle and the star the box centre is
+    // not the centroid. Anything deriving a hit area must use the drawn box rather than assume
+    // the shape is symmetric about its position.
+    const offCentre = ["triangle", "star"] as const
+    offCentre.forEach(shape => {
+      const geometry = pointShapeGeometry(shape, 8)
+      if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
+      const ys = geometry.points.map(p => p.y)
+      expect((Math.max(...ys) + Math.min(...ys)) / 2).not.toBeCloseTo(0, 2)
+    })
+
+    // and every other shape is symmetric, so its box centre and centroid agree
+    PointShapes.filter(s => s !== "circle" && !offCentre.includes(s as any)).forEach(shape => {
       const geometry = pointShapeGeometry(shape, 8)
       if (geometry.kind !== "polygon") throw new Error(`${shape} should be a polygon`)
       const ys = geometry.points.map(p => p.y)
       expect((Math.max(...ys) + Math.min(...ys)) / 2).toBeCloseTo(0, 6)
     })
-
-    const star = pointShapeGeometry("star", 8)
-    if (star.kind !== "polygon") throw new Error("star should be a polygon")
-    const starYs = star.points.map(p => p.y)
-    // the top vertex sits on the circumcircle, so the outline reaches exactly -R
-    expect(Math.min(...starYs)).toBeCloseTo(-1.420 * 8, 6)
   })
 
   it("scales linearly with the radius", () => {

--- a/v3/src/components/data-display/renderer/point-shapes.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.ts
@@ -99,9 +99,18 @@ const kShapeDefs: Record<PointShape, IShapeDef> = {
     geometry: r => {
       const s = K.triangle * r
       const h = s * Math.sqrt(3) / 2
-      // Bounding-box centered: a predictable hit area, and the shape sits on the same visual
-      // baseline as the square when the two are mixed.
-      return { kind: "polygon", points: [{ x: 0, y: -h / 2 }, { x: s / 2, y: h / 2 }, { x: -s / 2, y: h / 2 }] }
+      /*
+       * Centred on its centre of area, not its bounding box. An equilateral triangle's centroid
+       * sits h/6 below its box centre, so box-centring makes it read as sitting low: switching a
+       * category from another shape to this one visibly shifts its points down.
+       *
+       * The prototype centres it on the box instead, for a predictable hit area and a shared
+       * baseline with the square. That trades a visible positional bias for an alignment nicety,
+       * and in a scatterplot position is the data. Every shape now sits on its centre of area.
+       */
+      return { kind: "polygon", points: [
+        { x: 0, y: -2 * h / 3 }, { x: s / 2, y: h / 3 }, { x: -s / 2, y: h / 3 }
+      ] }
     },
     area: r => Math.sqrt(3) / 4 * (K.triangle * r) ** 2,
     extent: r => {

--- a/v3/src/components/data-display/renderer/point-shapes.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.ts
@@ -1,0 +1,192 @@
+import { PointShape } from "../../../utilities/point-shape-utils"
+
+/*
+ * The geometry of the seven point shapes, as a function of the point radius.
+ *
+ * One source for every surface that draws a shape: the canvas renderer, the PIXI renderer and the
+ * legend keys. Ported from the design prototype's js/shapes.js, which states the same contract --
+ * "ONE source of geometry for every place a shape appears" -- and whose constants these are.
+ *
+ * Circle is the reference and is unchanged from what CODAP has always drawn: radius r. Every other
+ * shape is normalized to about 90% of the circle's area. Equal area is deliberately not the target:
+ * straight edges and points read heavier than a circle of identical ink, so a small negative
+ * correction is what makes a triangle look like the same size point as a circle. The bounding boxes
+ * therefore differ between shapes, and that is intentional.
+ *
+ * Do not re-derive these constants. They are tuned, and the relative visual weight of the set
+ * depends on them.
+ */
+const K = {
+  square: 1.700,    // side
+  diamond: 1.200,   // half-diagonal
+  triangle: 2.550,  // side of the equilateral triangle
+  star: 1.420,      // outer radius
+  starInner: 0.48,  // inner/outer ratio - chunkier than the golden 0.382 so points survive at r = 3
+  plusArm: 0.410,   // arm half-width
+  plusLen: 1.080    // arm half-length
+} as const
+
+const kDegToRad = Math.PI / 180
+
+export interface IShapePoint {
+  x: number
+  y: number
+}
+
+export interface IShapeExtent {
+  w: number
+  h: number
+}
+
+/*
+ * A circle is an arc rather than a vertex list, so callers switch on `kind` instead of receiving a
+ * polygonal approximation. Both renderers can draw an arc directly, and approximating one would
+ * change how the shape CODAP already ships is rasterized.
+ */
+export type PointShapeGeometry =
+  | { kind: "circle", radius: number }
+  | { kind: "polygon", points: IShapePoint[] }
+
+// Vertices of a plus: an arm half-width `a` and half-length `L`, optionally rotated. X is this
+// same outline turned 45 degrees -- same ink, same weight, one set of numbers to maintain.
+function crossPoints(a: number, l: number, rotationDeg = 0): IShapePoint[] {
+  const pts: IShapePoint[] = [
+    { x: -a, y: -l }, { x: a, y: -l }, { x: a, y: -a }, { x: l, y: -a },
+    { x: l, y: a }, { x: a, y: a }, { x: a, y: l }, { x: -a, y: l },
+    { x: -a, y: a }, { x: -l, y: a }, { x: -l, y: -a }, { x: -a, y: -a }
+  ]
+  if (!rotationDeg) return pts
+
+  const cos = Math.cos(rotationDeg * kDegToRad)
+  const sin = Math.sin(rotationDeg * kDegToRad)
+  return pts.map(({ x, y }) => ({ x: x * cos - y * sin, y: x * sin + y * cos }))
+}
+
+// Ten alternating vertices, starting at the top and stepping 36 degrees.
+function starPoints(outerRadius: number, innerRatio: number): IShapePoint[] {
+  const pts: IShapePoint[] = []
+  for (let i = 0; i < 10; i++) {
+    const angle = (-90 + i * 36) * kDegToRad
+    const radius = i % 2 === 0 ? outerRadius : outerRadius * innerRatio
+    pts.push({ x: Math.cos(angle) * radius, y: Math.sin(angle) * radius })
+  }
+  return pts
+}
+
+interface IShapeDef {
+  geometry: (r: number) => PointShapeGeometry
+  area: (r: number) => number
+  extent: (r: number) => IShapeExtent
+}
+
+const kShapeDefs: Record<PointShape, IShapeDef> = {
+  circle: {
+    geometry: r => ({ kind: "circle", radius: r }),
+    area: r => Math.PI * r * r,
+    extent: r => ({ w: 2 * r, h: 2 * r })
+  },
+
+  square: {
+    geometry: r => {
+      const h = K.square * r / 2
+      return { kind: "polygon", points: [{ x: -h, y: -h }, { x: h, y: -h }, { x: h, y: h }, { x: -h, y: h }] }
+    },
+    area: r => (K.square * r) ** 2,
+    extent: r => ({ w: K.square * r, h: K.square * r })
+  },
+
+  triangle: {
+    geometry: r => {
+      const s = K.triangle * r
+      const h = s * Math.sqrt(3) / 2
+      // Bounding-box centered: a predictable hit area, and the shape sits on the same visual
+      // baseline as the square when the two are mixed.
+      return { kind: "polygon", points: [{ x: 0, y: -h / 2 }, { x: s / 2, y: h / 2 }, { x: -s / 2, y: h / 2 }] }
+    },
+    area: r => Math.sqrt(3) / 4 * (K.triangle * r) ** 2,
+    extent: r => {
+      const s = K.triangle * r
+      return { w: s, h: s * Math.sqrt(3) / 2 }
+    }
+  },
+
+  diamond: {
+    geometry: r => {
+      const d = K.diamond * r
+      return { kind: "polygon", points: [{ x: 0, y: -d }, { x: d, y: 0 }, { x: 0, y: d }, { x: -d, y: 0 }] }
+    },
+    area: r => 2 * (K.diamond * r) ** 2,
+    extent: r => {
+      const d = K.diamond * r
+      return { w: 2 * d, h: 2 * d }
+    }
+  },
+
+  star: {
+    geometry: r => ({ kind: "polygon", points: starPoints(K.star * r, K.starInner) }),
+    area: r => {
+      const outer = K.star * r
+      return 5 * K.starInner * outer * outer * Math.sin(36 * kDegToRad)
+    },
+    extent: r => {
+      const outer = K.star * r
+      return { w: 2 * outer * Math.sin(72 * kDegToRad), h: outer * (1 + Math.cos(36 * kDegToRad)) }
+    }
+  },
+
+  plus: {
+    geometry: r => ({ kind: "polygon", points: crossPoints(K.plusArm * r, K.plusLen * r) }),
+    area: r => {
+      const a = K.plusArm * r
+      const l = K.plusLen * r
+      return 8 * a * l - 4 * a * a
+    },
+    extent: r => {
+      const l = K.plusLen * r
+      return { w: 2 * l, h: 2 * l }
+    }
+  },
+
+  x: {
+    geometry: r => ({ kind: "polygon", points: crossPoints(K.plusArm * r, K.plusLen * r, 45) }),
+    area: r => kShapeDefs.plus.area(r),
+    extent: r => {
+      const a = K.plusArm * r
+      const l = K.plusLen * r
+      const e = (l + a) * Math.SQRT2 / 2
+      return { w: 2 * e, h: 2 * e }
+    }
+  }
+}
+
+/*
+ * The outline of `shape` at point radius `r`, centered on the origin, so a point is drawn with a
+ * single translate.
+ */
+export function pointShapeGeometry(shape: PointShape, r: number): PointShapeGeometry {
+  return kShapeDefs[shape].geometry(r)
+}
+
+// The ink area. Used to verify the normalization holds rather than by the renderers.
+export function pointShapeArea(shape: PointShape, r: number): number {
+  return kShapeDefs[shape].area(r)
+}
+
+/*
+ * The drawn bounding box, which is NOT 2r for anything but the circle -- a star is about 35% wider
+ * than a circle of the same visual weight. Hit testing needs this rather than the radius, or the
+ * points of a star are drawn outside the region that responds to a click.
+ */
+export function pointShapeExtent(shape: PointShape, r: number): IShapeExtent {
+  return kShapeDefs[shape].extent(r)
+}
+
+/*
+ * The distance from the center to the furthest point of the outline. The cheap basis for a
+ * shape-aware hit test: it never reports a hit short of the drawn ink, though it is generous in
+ * the concave regions of a plus or an X.
+ */
+export function pointShapeBoundingRadius(shape: PointShape, r: number): number {
+  const { w, h } = pointShapeExtent(shape, r)
+  return Math.max(w, h) / 2
+}

--- a/v3/src/components/data-display/renderer/point-shapes.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.ts
@@ -191,11 +191,46 @@ export function pointShapeExtent(shape: PointShape, r: number): IShapeExtent {
 }
 
 /*
- * The distance from the center to the furthest point of the outline. The cheap basis for a
- * shape-aware hit test: it never reports a hit short of the drawn ink, though it is generous in
- * the concave regions of a plus or an X.
+ * The distance from the center to the furthest point of the outline, measured from the vertices
+ * rather than the extent. The extent is the size of the drawn box, and for the triangle and the
+ * star that box is not centered on the point, so half of its larger side falls short of the ink:
+ * a triangle's apex sits at 2h/3 from the centroid while half its width is only s/2. Hit testing
+ * uses this to find candidates, so falling short means a click on the apex finds nothing.
  */
 export function pointShapeBoundingRadius(shape: PointShape, r: number): number {
-  const { w, h } = pointShapeExtent(shape, r)
-  return Math.max(w, h) / 2
+  const geometry = pointShapeGeometry(shape, r)
+  if (geometry.kind === "circle") return geometry.radius
+  return geometry.points.reduce((max, p) => Math.max(max, Math.hypot(p.x, p.y)), 0)
+}
+
+// Even-odd ray casting. Vertices are in shape-local coordinates, as is (x, y).
+function isPointInPolygon(points: IShapePoint[], x: number, y: number): boolean {
+  let inside = false
+  for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+    const { x: xi, y: yi } = points[i]
+    const { x: xj, y: yj } = points[j]
+    const straddlesRay = (yi > y) !== (yj > y)
+    if (straddlesRay && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
+/*
+ * Whether (dx, dy), relative to the point's center, is on the point.
+ *
+ * The drawn ink, unioned with the circle of radius r that CODAP has always used. Shape is a second
+ * encoding channel, so choosing one must not make a point harder to click than it was as a circle:
+ * testing the ink alone would open dead zones between a star's arms and in the notches of a plus,
+ * where the shape is narrower than the circle it replaced. The union keeps every shape at least as
+ * easy to hit as a circle while adding the ink that extends past it -- a star's tips, a square's
+ * corners, a triangle's apex -- so the target matches what is drawn wherever that is generous, and
+ * matches the old circle wherever it is not.
+ */
+export function isPointInShape(shape: PointShape, r: number, dx: number, dy: number): boolean {
+  if (dx * dx + dy * dy <= r * r) return true
+
+  const geometry = pointShapeGeometry(shape, r)
+  return geometry.kind === "circle" ? false : isPointInPolygon(geometry.points, dx, dy)
 }

--- a/v3/src/components/data-display/renderer/point-shapes.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.ts
@@ -100,13 +100,13 @@ const kShapeDefs: Record<PointShape, IShapeDef> = {
       const s = K.triangle * r
       const h = s * Math.sqrt(3) / 2
       /*
-       * Centred on its centre of area, not its bounding box. An equilateral triangle's centroid
-       * sits h/6 below its box centre, so box-centring makes it read as sitting low: switching a
+       * Centered on its center of area, not its bounding box. An equilateral triangle's centroid
+       * sits h/6 below its box center, so box-centering makes it read as sitting low: switching a
        * category from another shape to this one visibly shifts its points down.
        *
-       * The prototype centres it on the box instead, for a predictable hit area and a shared
+       * The prototype centers it on the box instead, for a predictable hit area and a shared
        * baseline with the square. That trades a visible positional bias for an alignment nicety,
-       * and in a scatterplot position is the data. Every shape now sits on its centre of area.
+       * and in a scatterplot position is the data. Every shape now sits on its center of area.
        */
       return { kind: "polygon", points: [
         { x: 0, y: -2 * h / 3 }, { x: s / 2, y: h / 3 }, { x: -s / 2, y: h / 3 }

--- a/v3/src/components/data-display/renderer/point-shapes.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.ts
@@ -1,10 +1,11 @@
 import { PointShape } from "../../../utilities/point-shape-utils"
+import { Extent, Point } from "../data-display-types"
 
 /*
  * The geometry of the seven point shapes, as a function of the point radius.
  *
- * One source for every surface that draws a shape. Ported from the design prototype's js/shapes.js,
- * whose constants these are.
+ * One source for every surface that draws a shape. The constants come from the design prototype
+ * the feature was specified from, and are tuned rather than derived.
  *
  * Circle is the reference, unchanged from what CODAP has always drawn: radius r. Every other shape
  * is normalized to about 90% of the circle's area rather than to equal area, because straight edges
@@ -26,16 +27,6 @@ const K = {
 
 const kDegToRad = Math.PI / 180
 
-export interface IShapePoint {
-  x: number
-  y: number
-}
-
-export interface IShapeExtent {
-  w: number
-  h: number
-}
-
 /*
  * A circle is an arc rather than a vertex list, so callers switch on `kind` instead of receiving a
  * polygonal approximation. Both renderers can draw an arc directly, and approximating one would
@@ -43,12 +34,12 @@ export interface IShapeExtent {
  */
 export type PointShapeGeometry =
   | { kind: "circle", radius: number }
-  | { kind: "polygon", points: IShapePoint[] }
+  | { kind: "polygon", points: Point[] }
 
-// Vertices of a plus: an arm half-width `a` and half-length `L`, optionally rotated. X is this
-// same outline turned 45 degrees -- same ink, same weight, one set of numbers to maintain.
-function crossPoints(a: number, l: number, rotationDeg = 0): IShapePoint[] {
-  const pts: IShapePoint[] = [
+// Vertices of a plus and X: an arm half-width `a` and half-length `L`, optionally rotated.
+// Plus is the default; X is this same outline turned 45 degrees.
+function crossPoints(a: number, l: number, rotationDeg = 0): Point[] {
+  const pts: Point[] = [
     { x: -a, y: -l }, { x: a, y: -l }, { x: a, y: -a }, { x: l, y: -a },
     { x: l, y: a }, { x: a, y: a }, { x: a, y: l }, { x: -a, y: l },
     { x: -a, y: a }, { x: -l, y: a }, { x: -l, y: -a }, { x: -a, y: -a }
@@ -61,8 +52,8 @@ function crossPoints(a: number, l: number, rotationDeg = 0): IShapePoint[] {
 }
 
 // Ten alternating vertices, starting at the top and stepping 36 degrees.
-function starPoints(outerRadius: number, innerRatio: number): IShapePoint[] {
-  const pts: IShapePoint[] = []
+function starPoints(outerRadius: number, innerRatio: number): Point[] {
+  const pts: Point[] = []
   for (let i = 0; i < 10; i++) {
     const angle = (-90 + i * 36) * kDegToRad
     const radius = i % 2 === 0 ? outerRadius : outerRadius * innerRatio
@@ -74,7 +65,7 @@ function starPoints(outerRadius: number, innerRatio: number): IShapePoint[] {
 interface IShapeDef {
   geometry: (r: number) => PointShapeGeometry
   area: (r: number) => number
-  extent: (r: number) => IShapeExtent
+  extent: (r: number) => Extent
 }
 
 const kShapeDefs: Record<PointShape, IShapeDef> = {
@@ -101,10 +92,7 @@ const kShapeDefs: Record<PointShape, IShapeDef> = {
        * Centered on its center of area, not its bounding box: a centroid sits h/6 below the box
        * center, so box-centering makes the triangle read as sitting low, and switching a category
        * to it visibly shifts the points down.
-       *
-       * The prototype centers on the box, buying a predictable hit area and a shared baseline with
-       * the square. On a plot a position is the data, so the bias costs more than the alignment
-       * gains.
+
        */
       return { kind: "polygon", points: [
         { x: 0, y: -2 * h / 3 }, { x: s / 2, y: h / 3 }, { x: -s / 2, y: h / 3 }
@@ -180,10 +168,9 @@ export function pointShapeArea(shape: PointShape, r: number): number {
 }
 
 /*
- * The drawn bounding box, which is NOT 2r for anything but the circle: a star is about 35% wider
- * than the circle it replaces. Used to size a shape against a box, and to check the normalization.
+ * The drawn bounding box. Used to size a shape against a box, and to check the normalization.
  */
-export function pointShapeExtent(shape: PointShape, r: number): IShapeExtent {
+export function pointShapeExtent(shape: PointShape, r: number): Extent {
   return kShapeDefs[shape].extent(r)
 }
 
@@ -201,7 +188,7 @@ export function pointShapeBoundingRadius(shape: PointShape, r: number): number {
 }
 
 // Even-odd ray casting. Vertices are in shape-local coordinates, as is (x, y).
-function isPointInPolygon(points: IShapePoint[], x: number, y: number): boolean {
+function isPointInPolygon(points: Point[], x: number, y: number): boolean {
   let inside = false
   for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
     const { x: xi, y: yi } = points[i]
@@ -215,7 +202,7 @@ function isPointInPolygon(points: IShapePoint[], x: number, y: number): boolean 
 }
 
 /*
- * Whether (dx, dy), relative to the point's center, is on the point.
+ * Whether (dx, dy), relative to a plotted point's center, hits it.
  *
  * The drawn ink, unioned with the circle of radius r that CODAP has always used. Shape is a second
  * encoding channel, so choosing one must not make a point harder to click than it was as a circle:

--- a/v3/src/components/data-display/renderer/point-shapes.ts
+++ b/v3/src/components/data-display/renderer/point-shapes.ts
@@ -3,18 +3,16 @@ import { PointShape } from "../../../utilities/point-shape-utils"
 /*
  * The geometry of the seven point shapes, as a function of the point radius.
  *
- * One source for every surface that draws a shape: the canvas renderer, the PIXI renderer and the
- * legend keys. Ported from the design prototype's js/shapes.js, which states the same contract --
- * "ONE source of geometry for every place a shape appears" -- and whose constants these are.
+ * One source for every surface that draws a shape. Ported from the design prototype's js/shapes.js,
+ * whose constants these are.
  *
- * Circle is the reference and is unchanged from what CODAP has always drawn: radius r. Every other
- * shape is normalized to about 90% of the circle's area. Equal area is deliberately not the target:
- * straight edges and points read heavier than a circle of identical ink, so a small negative
- * correction is what makes a triangle look like the same size point as a circle. The bounding boxes
- * therefore differ between shapes, and that is intentional.
+ * Circle is the reference, unchanged from what CODAP has always drawn: radius r. Every other shape
+ * is normalized to about 90% of the circle's area rather than to equal area, because straight edges
+ * and points read heavier than a circle of identical ink. Their bounding boxes therefore differ,
+ * which is intentional.
  *
- * Do not re-derive these constants. They are tuned, and the relative visual weight of the set
- * depends on them.
+ * Do not re-derive the constants. They are tuned, and the relative weight of the set depends on
+ * them.
  */
 const K = {
   square: 1.700,    // side
@@ -100,13 +98,13 @@ const kShapeDefs: Record<PointShape, IShapeDef> = {
       const s = K.triangle * r
       const h = s * Math.sqrt(3) / 2
       /*
-       * Centered on its center of area, not its bounding box. An equilateral triangle's centroid
-       * sits h/6 below its box center, so box-centering makes it read as sitting low: switching a
-       * category from another shape to this one visibly shifts its points down.
+       * Centered on its center of area, not its bounding box: a centroid sits h/6 below the box
+       * center, so box-centering makes the triangle read as sitting low, and switching a category
+       * to it visibly shifts the points down.
        *
-       * The prototype centers it on the box instead, for a predictable hit area and a shared
-       * baseline with the square. That trades a visible positional bias for an alignment nicety,
-       * and in a scatterplot position is the data. Every shape now sits on its center of area.
+       * The prototype centers on the box, buying a predictable hit area and a shared baseline with
+       * the square. On a plot a position is the data, so the bias costs more than the alignment
+       * gains.
        */
       return { kind: "polygon", points: [
         { x: 0, y: -2 * h / 3 }, { x: s / 2, y: h / 3 }, { x: -s / 2, y: h / 3 }
@@ -182,20 +180,19 @@ export function pointShapeArea(shape: PointShape, r: number): number {
 }
 
 /*
- * The drawn bounding box, which is NOT 2r for anything but the circle -- a star is about 35% wider
- * than a circle of the same visual weight. Hit testing needs this rather than the radius, or the
- * points of a star are drawn outside the region that responds to a click.
+ * The drawn bounding box, which is NOT 2r for anything but the circle: a star is about 35% wider
+ * than the circle it replaces. Used to size a shape against a box, and to check the normalization.
  */
 export function pointShapeExtent(shape: PointShape, r: number): IShapeExtent {
   return kShapeDefs[shape].extent(r)
 }
 
 /*
- * The distance from the center to the furthest point of the outline, measured from the vertices
- * rather than the extent. The extent is the size of the drawn box, and for the triangle and the
- * star that box is not centered on the point, so half of its larger side falls short of the ink:
- * a triangle's apex sits at 2h/3 from the centroid while half its width is only s/2. Hit testing
- * uses this to find candidates, so falling short means a click on the apex finds nothing.
+ * The distance from the center to the furthest vertex, which is what hit testing needs.
+ *
+ * Measured from the vertices rather than from the extent: the extent is the size of the drawn box,
+ * and a triangle's box is not centered on the point, so half its larger side stops short of the ink
+ * -- the apex sits at 2h/3 while half the width is s/2. A hit area sized that way misses the apex.
  */
 export function pointShapeBoundingRadius(shape: PointShape, r: number): number {
   const geometry = pointShapeGeometry(shape, r)

--- a/v3/src/components/graph/hooks/use-chart-dots.ts
+++ b/v3/src/components/graph/hooks/use-chart-dots.ts
@@ -34,11 +34,12 @@ export const useChartDots = (renderer?: PointRendererBase) => {
     baselineOffset = 0.5
 
   const refreshPointSelection = useCallback(() => {
-    const {pointColor, pointStrokeColor} = graphModel.pointDescription
+    const {pointColor, pointStrokeColor, pointShape} = graphModel.pointDescription
     const pointRadius = graphModel.getPointRadius()
     const selectedPointRadius = graphModel.getPointRadius('select')
     dataConfig && setPointSelection({
-      renderer, pointColor, pointStrokeColor, dataConfiguration: dataConfig, pointRadius, selectedPointRadius
+      renderer, pointColor, pointStrokeColor, pointShape, dataConfiguration: dataConfig, pointRadius,
+      selectedPointRadius
     })
   }, [dataConfig, graphModel, renderer])
 

--- a/v3/src/components/graph/hooks/use-dot-plot.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot.ts
@@ -69,19 +69,28 @@ export const useDotPlot = (renderer?: PointRendererBase) => {
   const secondaryMax = Number(secondaryAxisScale.range()[secondaryRangeIndex])
   const secondarySign = primaryIsBottom ? -1 : 1
   const baseCoord = primaryIsBottom ? secondaryMax : 0
-  const {pointColor, pointStrokeColor, pointShape} = graphModel.pointDescription
+  const {pointColor, pointStrokeColor} = graphModel.pointDescription
   const pointDisplayType = graphModel.plot.displayType
   const { isAnimating } = useDataDisplayAnimation()
 
   const refreshPointSelection = useCallback(() => {
     const pointRadius = graphModel.getPointRadius()
     const selectedPointRadius = graphModel.getPointRadius('select')
+    /*
+     * Read the appearance from the model here rather than closing over the values destructured
+     * above. A restyle can be driven by a reaction, which runs when the model changes and before
+     * the re-render that would rebuild this callback; a captured value restyles the plot to the
+     * appearance it had before that change, so each change only appears when the next one is made.
+     * The other plot types read these at call time for the same reason.
+     */
+    const { pointColor: color, pointStrokeColor: strokeColor, pointShape: shape } = graphModel.pointDescription
     dataConfig && setPointSelection({
-      renderer, dataConfiguration: dataConfig, pointRadius, pointColor, pointStrokeColor, pointShape,
+      renderer, dataConfiguration: dataConfig, pointRadius,
+      pointColor: color, pointStrokeColor: strokeColor, pointShape: shape,
       selectedPointRadius,
-      pointDisplayType
+      pointDisplayType: graphModel.plot.displayType
     })
-  }, [dataConfig, graphModel, renderer, pointColor, pointStrokeColor, pointShape, pointDisplayType])
+  }, [dataConfig, graphModel, renderer])
 
   const getPrimaryScreenCoord = useCallback((anID: string) => {
     const computePrimaryCoordProps: IComputePrimaryCoord = {

--- a/v3/src/components/graph/hooks/use-dot-plot.ts
+++ b/v3/src/components/graph/hooks/use-dot-plot.ts
@@ -69,7 +69,7 @@ export const useDotPlot = (renderer?: PointRendererBase) => {
   const secondaryMax = Number(secondaryAxisScale.range()[secondaryRangeIndex])
   const secondarySign = primaryIsBottom ? -1 : 1
   const baseCoord = primaryIsBottom ? secondaryMax : 0
-  const {pointColor, pointStrokeColor} = graphModel.pointDescription
+  const {pointColor, pointStrokeColor, pointShape} = graphModel.pointDescription
   const pointDisplayType = graphModel.plot.displayType
   const { isAnimating } = useDataDisplayAnimation()
 
@@ -77,10 +77,11 @@ export const useDotPlot = (renderer?: PointRendererBase) => {
     const pointRadius = graphModel.getPointRadius()
     const selectedPointRadius = graphModel.getPointRadius('select')
     dataConfig && setPointSelection({
-      renderer, dataConfiguration: dataConfig, pointRadius, pointColor, pointStrokeColor, selectedPointRadius,
+      renderer, dataConfiguration: dataConfig, pointRadius, pointColor, pointStrokeColor, pointShape,
+      selectedPointRadius,
       pointDisplayType
     })
-  }, [dataConfig, graphModel, renderer, pointColor, pointStrokeColor, pointDisplayType])
+  }, [dataConfig, graphModel, renderer, pointColor, pointStrokeColor, pointShape, pointDisplayType])
 
   const getPrimaryScreenCoord = useCallback((anID: string) => {
     const computePrimaryCoordProps: IComputePrimaryCoord = {

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -458,12 +458,14 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
    * A shape change alters only how each point is drawn, so a restyle suffices; positions and masks
    * are untouched, unlike a legend color change which can also change which points are plotted.
    *
-   * It has to be a restyle rather than a reposition: only setPointSelection writes the shape into
-   * a point's style. setPointCoordinates, which the reposition path uses, sets the fill but not the
-   * shape, and style updates merge -- so repositioning after a shape change leaves the old shape in
-   * place. That is why both shape sources are observed here rather than alongside the other point
-   * properties: the per-category shapes, and the display's own, which is what a plot with no legend
-   * attribute draws throughout.
+   * The restyle path is used because it is the cheaper of the two that can carry a shape, not
+   * because it is the only one: setPointCoordinates writes the shape as well, so that a point
+   * created by it is not drawn as a circle. Repositioning every point to change how they are drawn
+   * would be wasted work.
+   *
+   * Both shape sources are observed rather than sitting alongside the other point properties: the
+   * per-category shapes, and the display's own, which is what a plot with no legend attribute
+   * draws throughout.
    */
   useEffect(() => {
     return mstReaction(

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -146,6 +146,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
         dataConfiguration,
         pointRadius: graphModel.getPointRadius(),
         pointColor: graphModel.pointDescription.pointColor,
+        pointShape: graphModel.pointDescription.pointShape,
         pointDisplayType: graphModel.plot.displayType,
         pointStrokeColor: graphModel.pointDescription.pointStrokeColor,
         renderer,

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -454,19 +454,8 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       }, {name: "usePlot [legendColorChange]"}, graphModel)
   }, [graphModel, callRefreshPointPositions])
 
-  /*
-   * A shape change alters only how each point is drawn, so a restyle suffices; positions and masks
-   * are untouched, unlike a legend color change which can also change which points are plotted.
-   *
-   * The restyle path is used because it is the cheaper of the two that can carry a shape, not
-   * because it is the only one: setPointCoordinates writes the shape as well, so that a point
-   * created by it is not drawn as a circle. Repositioning every point to change how they are drawn
-   * would be wasted work.
-   *
-   * Both shape sources are observed rather than sitting alongside the other point properties: the
-   * per-category shapes, and the display's own, which is what a plot with no legend attribute
-   * draws throughout.
-   */
+  // A shape change alters only how each point is drawn, so a restyle suffices: positions and masks
+  // are untouched, unlike a legend color change, which can also change which points are plotted.
   useEffect(() => {
     return mstReaction(
       () => [graphModel.dataConfiguration.legendShapeDomain, graphModel.pointDescription.pointShape],

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -453,6 +453,16 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       }, {name: "usePlot [legendColorChange]"}, graphModel)
   }, [graphModel, callRefreshPointPositions])
 
+  // A shape change alters only how each point is drawn, so a restyle suffices; positions and masks
+  // are untouched, unlike a legend colour change which can also change which points are plotted.
+  useEffect(() => {
+    return mstReaction(
+      () => graphModel.dataConfiguration.legendShapeDomain,
+      () => {
+        refreshPointSelection()
+      }, {name: "usePlot [legendShapeChange]"}, graphModel)
+  }, [graphModel, refreshPointSelection])
+
   // respond to pointsNeedUpdating becoming false; that is when the points have been updated
   // Happens when the number of plots has changed for now. Possibly other situations in the future.
   useEffect(() => {

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -454,7 +454,7 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
   }, [graphModel, callRefreshPointPositions])
 
   // A shape change alters only how each point is drawn, so a restyle suffices; positions and masks
-  // are untouched, unlike a legend colour change which can also change which points are plotted.
+  // are untouched, unlike a legend color change which can also change which points are plotted.
   useEffect(() => {
     return mstReaction(
       () => graphModel.dataConfiguration.legendShapeDomain,

--- a/v3/src/components/graph/hooks/use-plot.ts
+++ b/v3/src/components/graph/hooks/use-plot.ts
@@ -453,14 +453,23 @@ export const usePlotResponders = (props: IPlotResponderProps) => {
       }, {name: "usePlot [legendColorChange]"}, graphModel)
   }, [graphModel, callRefreshPointPositions])
 
-  // A shape change alters only how each point is drawn, so a restyle suffices; positions and masks
-  // are untouched, unlike a legend color change which can also change which points are plotted.
+  /*
+   * A shape change alters only how each point is drawn, so a restyle suffices; positions and masks
+   * are untouched, unlike a legend color change which can also change which points are plotted.
+   *
+   * It has to be a restyle rather than a reposition: only setPointSelection writes the shape into
+   * a point's style. setPointCoordinates, which the reposition path uses, sets the fill but not the
+   * shape, and style updates merge -- so repositioning after a shape change leaves the old shape in
+   * place. That is why both shape sources are observed here rather than alongside the other point
+   * properties: the per-category shapes, and the display's own, which is what a plot with no legend
+   * attribute draws throughout.
+   */
   useEffect(() => {
     return mstReaction(
-      () => graphModel.dataConfiguration.legendShapeDomain,
+      () => [graphModel.dataConfiguration.legendShapeDomain, graphModel.pointDescription.pointShape],
       () => {
         refreshPointSelection()
-      }, {name: "usePlot [legendShapeChange]"}, graphModel)
+      }, {name: "usePlot [shapeChange]", equals: comparer.structural}, graphModel)
   }, [graphModel, refreshPointSelection])
 
   // respond to pointsNeedUpdating becoming false; that is when the points have been updated

--- a/v3/src/components/graph/models/graph-controller.ts
+++ b/v3/src/components/graph/models/graph-controller.ts
@@ -77,7 +77,7 @@ export class GraphController {
         startAnimation = graphModel.startAnimation,
         stopAnimation = graphModel.stopAnimation
       dataConfiguration && matchCirclesToData({
-        dataConfiguration, renderer, pointDisplayType,
+        dataConfiguration, renderer, pointDisplayType, pointShape: graphModel.pointDescription.pointShape,
         pointRadius, startAnimation, stopAnimation, instanceId, pointColor, pointStrokeColor
       })
     }

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -1139,6 +1139,20 @@ describe("DataConfigurationModel legend point shapes", () => {
     expect(tree.config.getLegendShapeForCase(caseId, "plus")).toBe("x")
   })
 
+  it("works when called as a detached reference, which is how the plots call it", () => {
+    /*
+     * A plot hands these to setPointCoordinates as bare function references --
+     * `getLegendColor = dataConfig.getLegendColorForCase` -- and calls them unbound, so `this`
+     * inside them is undefined. Anything they need from the model has to come through `self`.
+     */
+    const caseId = tree.data.items[0].__id__
+    const getShape = tree.config.getLegendShapeForCase
+    const getColor = tree.config.getLegendColorForCase
+
+    expect(() => getShape(caseId, "star")).not.toThrow()
+    expect(() => getColor(caseId)).not.toThrow()
+  })
+
   it("falls back rather than speaking for a group when the legend is below the plotted cases", () => {
     /*
      * With the legend attribute in a more childmost collection than the plotted cases, a point

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -1139,6 +1139,28 @@ describe("DataConfigurationModel legend point shapes", () => {
     expect(tree.config.getLegendShapeForCase(caseId, "plus")).toBe("x")
   })
 
+  it("falls back rather than speaking for a group when the legend is below the plotted cases", () => {
+    /*
+     * With the legend attribute in a more childmost collection than the plotted cases, a point
+     * stands for several children at once and getStrValue would resolve through an arbitrary one of
+     * them, so that child's shape would be attributed to the whole group. The color path already
+     * refuses this; the shape path has to agree with it.
+     */
+    tree.data.addAttribute({ id: "xId", name: "x" })
+    tree.data.setCaseValues([
+      { __id__: "c1", xId: "shared" },
+      { __id__: "c2", xId: "shared" }
+    ])
+    tree.config.setAttribute("x", { attributeID: "xId" })
+    // x becomes the parent collection, leaving the legend childmost
+    tree.data.moveAttributeToNewCollection("xId")
+    expect(tree.config.legendCollectionIsMoreChildmost).toBe(true)
+
+    tree.config.setLegendShapeForCategory("land", "diamond")
+    const parentCaseId = tree.data.items[0].__id__
+    expect(tree.config.getLegendShapeForCase(parentCaseId, "star")).toBe("star")
+  })
+
   it("falls back to the default when there is no legend attribute", () => {
     tree.config.setAttribute("legend", { attributeID: "" })
     // no category set to consult, so reads resolve rather than returning undefined

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -1113,6 +1113,32 @@ describe("DataConfigurationModel legend point shapes", () => {
     expect(categorySet?.shapeForCategory("land")).toBe("diamond")
   })
 
+  it("inherits the display's shape for a category with none of its own", () => {
+    /*
+     * A shape chosen before a legend existed must survive the legend being added. Colors are
+     * replaced by something meaningful when a legend takes over -- distinct palette colors per
+     * category -- but there is no shape palette, so replacing shapes with the bare default would
+     * discard the user's choice and hand back nothing.
+     */
+    expect(tree.config.getLegendShapeForCategory("land", "star")).toBe("star")
+    expect(tree.config.getLegendShapeForCategory("water", "star")).toBe("star")
+  })
+
+  it("prefers a category's own shape over the inherited one", () => {
+    tree.config.setLegendShapeForCategory("land", "diamond")
+    expect(tree.config.getLegendShapeForCategory("land", "star")).toBe("diamond")
+    // its siblings still inherit
+    expect(tree.config.getLegendShapeForCategory("water", "star")).toBe("star")
+  })
+
+  it("resolves a case to the inherited shape when its category has none", () => {
+    const caseId = tree.data.itemIds[0]
+    expect(tree.config.getLegendShapeForCase(caseId, "plus")).toBe("plus")
+
+    tree.config.setLegendShapeForCategory("land", "x")
+    expect(tree.config.getLegendShapeForCase(caseId, "plus")).toBe("x")
+  })
+
   it("falls back to the default when there is no legend attribute", () => {
     tree.config.setAttribute("legend", { attributeID: "" })
     // no category set to consult, so reads resolve rather than returning undefined

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -39,6 +39,11 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
     const pointRadius = graphModel.getPointRadius()
     const legendAttrID = dataConfig?.attributeID('legend')
     const getLegendColor = legendAttrID ? dataConfig?.getLegendColorForCase : undefined
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = graphModel.pointDescription.pointShape
+    const getLegendShape = (anID: string) =>
+      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
     const pointDisplayType = "bars"
     const isFormulaDriven = barChartModel.breakdownType === "formula"
 
@@ -177,7 +182,8 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
     setPointCoordinates({
       anchor, dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
       renderer, selectedOnly, pointColor, pointStrokeColor, pointDisplayType,
-      getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating, getWidth, getHeight
+      getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
+      getWidth, getHeight
     })
   }, [abovePointsGroupRef, barChartModel, dataset, graphLayout, graphModel, isAnimating, layout,
     renderer, primaryScreenCoord, secondaryScreenCoord, subPlotCells])

--- a/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
+++ b/v3/src/components/graph/plots/bar-chart/bar-chart.tsx
@@ -8,6 +8,7 @@ import { useTileModelContext } from "../../../../hooks/use-tile-model-context"
 import { tileNotification } from "../../../../models/tiles/tile-notifications"
 import { EditFormulaModal } from "../../../common/edit-formula-modal"
 import { kMain } from "../../../data-display/data-display-types"
+import { legendShapeGetter } from "../../../data-display/data-display-utils"
 import { circleAnchor } from "../../../data-display/renderer"
 import { IBarCover, IPlotProps } from "../../graphing-types"
 import { useChartDots } from "../../hooks/use-chart-dots"
@@ -39,11 +40,6 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
     const pointRadius = graphModel.getPointRadius()
     const legendAttrID = dataConfig?.attributeID('legend')
     const getLegendColor = legendAttrID ? dataConfig?.getLegendColorForCase : undefined
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = graphModel.pointDescription.pointShape
-    const getLegendShape = (anID: string) =>
-      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
     const pointDisplayType = "bars"
     const isFormulaDriven = barChartModel.breakdownType === "formula"
 
@@ -182,7 +178,8 @@ export const BarChart = observer(function BarChart({ abovePointsGroupRef, render
     setPointCoordinates({
       anchor, dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'),
       renderer, selectedOnly, pointColor, pointStrokeColor, pointDisplayType,
-      getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
+      getScreenX, getScreenY, getLegendColor,
+      getLegendShape: legendShapeGetter(dataConfig, graphModel.pointDescription), getAnimationEnabled: isAnimating,
       getWidth, getHeight
     })
   }, [abovePointsGroupRef, barChartModel, dataset, graphLayout, graphModel, isAnimating, layout,

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
@@ -41,12 +41,17 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({renderer, abovePoi
 
     const getLegendColor = dataConfig?.attributeID("legend")
       ? dataConfig?.getLegendColorForCase : undefined
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = graphModel.pointDescription.pointShape
+    const getLegendShape = (anID: string) =>
+      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     setPointCoordinates({
       pointRadius: graphModel.getPointRadius(),
       selectedPointRadius: graphModel.getPointRadius("select"),
       renderer, selectedOnly, pointColor, pointStrokeColor,
-      getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating,
+      getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
       pointDisplayType, anchor: circleAnchor, dataset
     })
   }, [addBinBoundaryDragHandlers, binnedPlot, dataConfig, dataset, drawBinBoundaries,

--- a/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
+++ b/v3/src/components/graph/plots/binned-dot-plot/binned-dot-plot.tsx
@@ -11,6 +11,7 @@ import { useDotPlotDragDrop } from "../../hooks/use-dot-plot-drag-drop"
 import {useRendererDragHandlers, usePlotResponders} from "../../hooks/use-plot"
 import { setPointCoordinates } from "../../utilities/graph-utils"
 import { isBinnedDotPlotModel } from "./binned-dot-plot-model"
+import { legendShapeGetter } from "../../../data-display/data-display-utils"
 
 export const BinnedDotPlot = observer(function BinnedDotPlot({renderer, abovePointsGroupRef}: IPlotProps) {
   const { dataset, dataConfig, getPrimaryScreenCoord, getSecondaryScreenCoord, graphModel, isAnimating, layout,
@@ -41,17 +42,13 @@ export const BinnedDotPlot = observer(function BinnedDotPlot({renderer, abovePoi
 
     const getLegendColor = dataConfig?.attributeID("legend")
       ? dataConfig?.getLegendColorForCase : undefined
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = graphModel.pointDescription.pointShape
-    const getLegendShape = (anID: string) =>
-      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     setPointCoordinates({
       pointRadius: graphModel.getPointRadius(),
       selectedPointRadius: graphModel.getPointRadius("select"),
       renderer, selectedOnly, pointColor, pointStrokeColor,
-      getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
+      getScreenX, getScreenY, getLegendColor, 
+      getLegendShape: legendShapeGetter(dataConfig, graphModel.pointDescription), getAnimationEnabled: isAnimating,
       pointDisplayType, anchor: circleAnchor, dataset
     })
   }, [addBinBoundaryDragHandlers, binnedPlot, dataConfig, dataset, drawBinBoundaries,

--- a/v3/src/components/graph/plots/case-plot/case-plot.tsx
+++ b/v3/src/components/graph/plots/case-plot/case-plot.tsx
@@ -3,7 +3,7 @@ import {useCallback, useEffect, useRef, useState} from "react"
 import {useDataSetContext} from "../../../../hooks/use-data-set-context"
 import {mstReaction} from "../../../../utilities/mst-reaction"
 import { CaseData } from "../../../data-display/d3-types"
-import {handleClickOnCase, setPointSelection} from "../../../data-display/data-display-utils"
+import {handleClickOnCase, setPointSelection, legendShapeGetter } from "../../../data-display/data-display-utils"
 import {useDataDisplayAnimation} from "../../../data-display/hooks/use-data-display-animation"
 import { IPoint, IPointMetadata } from "../../../data-display/renderer"
 import { IPlotProps } from "../../graphing-types"
@@ -101,15 +101,11 @@ export const CasePlot = function CasePlot({ renderer }: IPlotProps) {
       getLegendColor = dataConfiguration?.attributeID('legend')
         ? dataConfiguration?.getLegendColorForCase : undefined
 
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = graphModel.pointDescription.pointShape
-    const getLegendShape = (anID: string) =>
-      dataConfiguration?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     setPointCoordinates({
       dataset, pointRadius, selectedPointRadius, renderer, selectedOnly,
-      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getLegendShape,
+      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, 
+      getLegendShape: legendShapeGetter(dataConfiguration, graphModel.pointDescription),
       getAnimationEnabled: isAnimating
     })
   }, [renderer, graphModel, layout, dataConfiguration, dataset, isAnimating])

--- a/v3/src/components/graph/plots/case-plot/case-plot.tsx
+++ b/v3/src/components/graph/plots/case-plot/case-plot.tsx
@@ -77,11 +77,11 @@ export const CasePlot = function CasePlot({ renderer }: IPlotProps) {
   useRendererDragHandlers(renderer, { start: onDragStart, drag: onDrag, end: onDragEnd })
 
   const refreshPointSelection = useCallback(() => {
-    const {pointColor, pointStrokeColor} = graphModel.pointDescription,
+    const {pointColor, pointStrokeColor, pointShape} = graphModel.pointDescription,
       selectedPointRadius = graphModel.getPointRadius('select')
       dataConfiguration && setPointSelection({
         renderer, dataConfiguration, pointRadius: graphModel.getPointRadius(), selectedPointRadius,
-        pointColor, pointStrokeColor
+        pointColor, pointStrokeColor, pointShape
       })
   }, [graphModel, dataConfiguration, renderer])
 

--- a/v3/src/components/graph/plots/case-plot/case-plot.tsx
+++ b/v3/src/components/graph/plots/case-plot/case-plot.tsx
@@ -101,9 +101,16 @@ export const CasePlot = function CasePlot({ renderer }: IPlotProps) {
       getLegendColor = dataConfiguration?.attributeID('legend')
         ? dataConfiguration?.getLegendColorForCase : undefined
 
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = graphModel.pointDescription.pointShape
+    const getLegendShape = (anID: string) =>
+      dataConfiguration?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
+
     setPointCoordinates({
       dataset, pointRadius, selectedPointRadius, renderer, selectedOnly,
-      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
+      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getLegendShape,
+      getAnimationEnabled: isAnimating
     })
   }, [renderer, graphModel, layout, dataConfiguration, dataset, isAnimating])
 

--- a/v3/src/components/graph/plots/dot-chart/dot-chart.tsx
+++ b/v3/src/components/graph/plots/dot-chart/dot-chart.tsx
@@ -1,7 +1,7 @@
 import { observer } from "mobx-react-lite"
 import { useCallback, useEffect } from "react"
 import { mstReaction } from "../../../../utilities/mst-reaction"
-import { handleClickOnCase } from "../../../data-display/data-display-utils"
+import { handleClickOnCase, legendShapeGetter } from "../../../data-display/data-display-utils"
 import { circleAnchor, IPoint, IPointMetadata } from "../../../data-display/renderer"
 import { IPlotProps } from "../../graphing-types"
 import { useChartDots } from "../../hooks/use-chart-dots"
@@ -20,11 +20,6 @@ export const DotChart = observer(function DotChart({ renderer }: IPlotProps) {
     const pointRadius = graphModel.getPointRadius()
     const legendAttrID = dataConfig?.attributeID('legend')
     const getLegendColor = legendAttrID ? dataConfig?.getLegendColorForCase : undefined
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = graphModel.pointDescription.pointShape
-    const getLegendShape = (anID: string) =>
-      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     const getPrimaryScreenCoord = (anID: string) => primaryScreenCoord({cellIndices, numPointsInRow}, anID)
     const getSecondaryScreenCoord = (anID: string) => secondaryScreenCoord({cellIndices, overlap}, anID)
@@ -34,7 +29,8 @@ export const DotChart = observer(function DotChart({ renderer }: IPlotProps) {
     const anchor = circleAnchor
     setPointCoordinates({
       anchor, dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'), renderer, selectedOnly,
-      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getLegendShape,
+      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, 
+      getLegendShape: legendShapeGetter(dataConfig, graphModel.pointDescription),
       getAnimationEnabled: isAnimating
     })
   }, [dataset, graphModel, isAnimating, renderer, primaryScreenCoord, secondaryScreenCoord, subPlotCells])

--- a/v3/src/components/graph/plots/dot-chart/dot-chart.tsx
+++ b/v3/src/components/graph/plots/dot-chart/dot-chart.tsx
@@ -20,6 +20,11 @@ export const DotChart = observer(function DotChart({ renderer }: IPlotProps) {
     const pointRadius = graphModel.getPointRadius()
     const legendAttrID = dataConfig?.attributeID('legend')
     const getLegendColor = legendAttrID ? dataConfig?.getLegendColorForCase : undefined
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = graphModel.pointDescription.pointShape
+    const getLegendShape = (anID: string) =>
+      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     const getPrimaryScreenCoord = (anID: string) => primaryScreenCoord({cellIndices, numPointsInRow}, anID)
     const getSecondaryScreenCoord = (anID: string) => secondaryScreenCoord({cellIndices, overlap}, anID)
@@ -29,7 +34,8 @@ export const DotChart = observer(function DotChart({ renderer }: IPlotProps) {
     const anchor = circleAnchor
     setPointCoordinates({
       anchor, dataset, pointRadius, selectedPointRadius: graphModel.getPointRadius('select'), renderer, selectedOnly,
-      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating
+      pointColor, pointStrokeColor, getScreenX, getScreenY, getLegendColor, getLegendShape,
+      getAnimationEnabled: isAnimating
     })
   }, [dataset, graphModel, isAnimating, renderer, primaryScreenCoord, secondaryScreenCoord, subPlotCells])
 

--- a/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
+++ b/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
@@ -156,6 +156,11 @@ export const DotLinePlot = observer(function DotLinePlot({ renderer }: IPlotProp
 
       const getLegendColor = dataConfig?.attributeID('legend')
         ? dataConfig?.getLegendColorForCase : undefined
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = graphModel.pointDescription.pointShape
+    const getLegendShape = (anID: string) =>
+      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
       const anchor = pointDisplayType === "bars"
         ? primaryIsBottom ? hBarAnchor : vBarAnchor
@@ -171,7 +176,7 @@ export const DotLinePlot = observer(function DotLinePlot({ renderer }: IPlotProp
         pointRadius: graphModel.getPointRadius(),
         selectedPointRadius: graphModel.getPointRadius('select'),
         renderer, selectedOnly, pointColor, pointStrokeColor,
-        getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating,
+        getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
         pointDisplayType, getWidth, getHeight, anchor, dataset
       })
     },

--- a/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
+++ b/v3/src/components/graph/plots/dot-plot/dot-line-plot.tsx
@@ -11,6 +11,7 @@ import { useDotPlot } from "../../hooks/use-dot-plot"
 import { useDotPlotDragDrop } from "../../hooks/use-dot-plot-drag-drop"
 import { useRendererDragHandlers, usePlotResponders } from "../../hooks/use-plot"
 import { setPointCoordinates } from "../../utilities/graph-utils"
+import { legendShapeGetter } from "../../../data-display/data-display-utils"
 import {
   computeBinPlacements, computePrimaryCoord, computeSecondaryCoord, IComputePrimaryCoord
 } from "./dot-plot-utils"
@@ -156,11 +157,6 @@ export const DotLinePlot = observer(function DotLinePlot({ renderer }: IPlotProp
 
       const getLegendColor = dataConfig?.attributeID('legend')
         ? dataConfig?.getLegendColorForCase : undefined
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = graphModel.pointDescription.pointShape
-    const getLegendShape = (anID: string) =>
-      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
       const anchor = pointDisplayType === "bars"
         ? primaryIsBottom ? hBarAnchor : vBarAnchor
@@ -176,7 +172,8 @@ export const DotLinePlot = observer(function DotLinePlot({ renderer }: IPlotProp
         pointRadius: graphModel.getPointRadius(),
         selectedPointRadius: graphModel.getPointRadius('select'),
         renderer, selectedOnly, pointColor, pointStrokeColor,
-        getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
+        getScreenX, getScreenY, getLegendColor, 
+      getLegendShape: legendShapeGetter(dataConfig, graphModel.pointDescription), getAnimationEnabled: isAnimating,
         pointDisplayType, getWidth, getHeight, anchor, dataset
       })
     },

--- a/v3/src/components/graph/plots/histogram/histogram.tsx
+++ b/v3/src/components/graph/plots/histogram/histogram.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from "react"
 import { createPortal } from "react-dom"
 import { mstAutorun } from "../../../../utilities/mst-autorun"
 import { GraphAttrRole } from "../../../data-display/data-display-types"
+import { legendShapeGetter } from "../../../data-display/data-display-utils"
 import { circleAnchor } from "../../../data-display/renderer"
 import { IBarCover, IPlotProps } from "../../graphing-types"
 import { useBinBoundaryDrag } from "../../hooks/use-bin-boundary-drag"
@@ -139,11 +140,6 @@ export const Histogram = observer(function Histogram({ abovePointsGroupRef, rend
     const getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord
     const getScreenY = primaryIsBottom ? getSecondaryScreenCoord : getPrimaryScreenCoord
     const getLegendColor = dataConfig?.attributeID("legend") ? dataConfig?.getLegendColorForCase : undefined
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = graphModel.pointDescription.pointShape
-    const getLegendShape = (anID: string) =>
-      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     // build and render bar cover elements that will handle click events for the fused points
     if (dataConfig && abovePointsGroupRef?.current) {
@@ -199,7 +195,8 @@ export const Histogram = observer(function Histogram({ abovePointsGroupRef, rend
       pointRadius: graphModel.getPointRadius(),
       selectedPointRadius: graphModel.getPointRadius("select"),
       renderer, selectedOnly, pointColor, pointStrokeColor, getWidth, getHeight,
-      getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
+      getScreenX, getScreenY, getLegendColor, 
+      getLegendShape: legendShapeGetter(dataConfig, graphModel.pointDescription), getAnimationEnabled: isAnimating,
       pointDisplayType: "bars", dataset
     })
   }, [abovePointsGroupRef, addHistogramBinDragHandlers, binnedPlot, dataConfig, dataset,

--- a/v3/src/components/graph/plots/histogram/histogram.tsx
+++ b/v3/src/components/graph/plots/histogram/histogram.tsx
@@ -139,6 +139,11 @@ export const Histogram = observer(function Histogram({ abovePointsGroupRef, rend
     const getScreenX = primaryIsBottom ? getPrimaryScreenCoord : getSecondaryScreenCoord
     const getScreenY = primaryIsBottom ? getSecondaryScreenCoord : getPrimaryScreenCoord
     const getLegendColor = dataConfig?.attributeID("legend") ? dataConfig?.getLegendColorForCase : undefined
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = graphModel.pointDescription.pointShape
+    const getLegendShape = (anID: string) =>
+      dataConfig?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     // build and render bar cover elements that will handle click events for the fused points
     if (dataConfig && abovePointsGroupRef?.current) {
@@ -194,7 +199,7 @@ export const Histogram = observer(function Histogram({ abovePointsGroupRef, rend
       pointRadius: graphModel.getPointRadius(),
       selectedPointRadius: graphModel.getPointRadius("select"),
       renderer, selectedOnly, pointColor, pointStrokeColor, getWidth, getHeight,
-      getScreenX, getScreenY, getLegendColor, getAnimationEnabled: isAnimating,
+      getScreenX, getScreenY, getLegendColor, getLegendShape, getAnimationEnabled: isAnimating,
       pointDisplayType: "bars", dataset
     })
   }, [abovePointsGroupRef, addHistogramBinDragHandlers, binnedPlot, dataConfig, dataset,

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -218,12 +218,13 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
   // When caseIds is provided, only those cases' points are restyled (delta path used during a
   // marquee drag); otherwise every point is restyled.
   const refreshPointSelection = useCallback((caseIds?: Set<string>) => {
-    const {pointColor, pointStrokeColor} = graphModel.pointDescription
+    const {pointColor, pointStrokeColor, pointShape} = graphModel.pointDescription
     dataConfiguration && setPointSelection(
       {
         renderer, dataConfiguration, pointRadius: graphModel.getPointRadius(),
         selectedPointRadius: selectedPointRadiusRef.current,
-        pointColor, pointStrokeColor, getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex
+        pointColor, pointStrokeColor, pointShape,
+        getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex
       }, caseIds, dataConfiguration.numberOfPlots)
     // Restyle the residual points so their selection halo tracks the upper plot's. This is a
     // style-only pass (no predictor/residual recompute, no data join), so selecting cases doesn't

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -18,7 +18,7 @@ import { getDomainExtentForPixelWidth } from "../../../axis/axis-utils"
 import { If } from "../../../common/if"
 import { CaseData } from "../../../data-display/d3-types"
 import { ID3Tip } from "../../../data-display/data-display-types"
-import { handleClickOnCase, setPointSelection } from "../../../data-display/data-display-utils"
+import { handleClickOnCase, setPointSelection, legendShapeGetter } from "../../../data-display/data-display-utils"
 import { dataDisplayGetNumericValue } from "../../../data-display/data-display-value-utils"
 import {
   ConnectingLines, IConnectingLinesRenderInput
@@ -349,16 +349,12 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
       {pointColor, pointStrokeColor} = graphModel.pointDescription,
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
 
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = graphModel.pointDescription.pointShape
-    const getLegendShape = (anID: string) =>
-      dataConfiguration?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
 
     setPointCoordinates({
       dataset, renderer, pointRadius: graphModel.getPointRadius(),
       selectedPointRadius: selectedPointRadiusRef.current,
-      selectedOnly, getScreenX, getScreenY, getLegendColor, getLegendShape,
+      selectedOnly, getScreenX, getScreenY, getLegendColor, 
+      getLegendShape: legendShapeGetter(dataConfiguration, graphModel.pointDescription),
       getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex,
       pointColor, pointStrokeColor, getAnimationEnabled: isAnimating
     })

--- a/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
+++ b/v3/src/components/graph/plots/scatter-plot/scatter-plot.tsx
@@ -349,10 +349,16 @@ export const ScatterPlot = observer(function ScatterPlot({ renderer }: IPlotProp
       {pointColor, pointStrokeColor} = graphModel.pointDescription,
       getLegendColor = legendAttrID ? dataConfiguration?.getLegendColorForCase : undefined
 
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = graphModel.pointDescription.pointShape
+    const getLegendShape = (anID: string) =>
+      dataConfiguration?.getLegendShapeForCase(anID, shapeIfNoCategory) ?? shapeIfNoCategory
+
     setPointCoordinates({
       dataset, renderer, pointRadius: graphModel.getPointRadius(),
       selectedPointRadius: selectedPointRadiusRef.current,
-      selectedOnly, getScreenX, getScreenY, getLegendColor,
+      selectedOnly, getScreenX, getScreenY, getLegendColor, getLegendShape,
       getPointColorAtIndex: graphModel.pointDescription.pointColorAtIndex,
       pointColor, pointStrokeColor, getAnimationEnabled: isAnimating
     })

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -410,7 +410,7 @@ describe("setPointCoordinates point shapes", () => {
    * from. A shape supplied only by the selection-restyle path leaves every new point a circle until
    * something unrelated restyles it -- adding a case to a plot with shapes is enough to show it.
    */
-  const makeRenderer = (caseIDs: string[]) => {
+  const stubPointTarget = (caseIDs: string[]) => {
     const styles: Record<string, IPointStyle> = {}
     return {
       styles,
@@ -428,7 +428,7 @@ describe("setPointCoordinates point shapes", () => {
 
   const run = (renderer: any, getLegendShape?: (anID: string) => any) => {
     setPointCoordinates({
-      renderer: renderer as any,
+      renderer,
       pointRadius: 5,
       selectedPointRadius: 7,
       pointColor: "#123456",
@@ -441,18 +441,18 @@ describe("setPointCoordinates point shapes", () => {
   }
 
   it("styles each point with the shape it resolves for that case", () => {
-    const renderer = makeRenderer(["c1", "c2"])
-    run(renderer, (anID: string) => (anID === "c1" ? "star" : "triangle"))
+    const target = stubPointTarget(["c1", "c2"])
+    run(target, (anID: string) => (anID === "c1" ? "star" : "triangle"))
 
-    expect(renderer.styles.c1.shape).toBe("star")
-    expect(renderer.styles.c2.shape).toBe("triangle")
+    expect(target.styles.c1.shape).toBe("star")
+    expect(target.styles.c2.shape).toBe("triangle")
   })
 
   it("leaves the shape alone when no resolver is supplied", () => {
     // callers that predate shapes must keep drawing whatever the renderer already had
-    const renderer = makeRenderer(["c1"])
-    run(renderer, undefined)
+    const target = stubPointTarget(["c1"])
+    run(target, undefined)
 
-    expect(renderer.styles.c1).not.toHaveProperty("shape")
+    expect(target.styles.c1).not.toHaveProperty("shape")
   })
 })

--- a/v3/src/components/graph/utilities/graph-utils.test.ts
+++ b/v3/src/components/graph/utilities/graph-utils.test.ts
@@ -1,8 +1,9 @@
 import {ptInRect} from "../../data-display/data-display-utils"
 import { GraphLayout } from "../models/graph-layout"
+import { IPointStyle } from "../../data-display/renderer/point-renderer-types"
 import {
   dateTimeSlopeUnit, equationString, formatDateDuration, formatValue, kMinus, leastSquaresLinearRegression,
-  lineToAxisIntercepts, lsrlEquationString, valueLabelString
+  lineToAxisIntercepts, lsrlEquationString, setPointCoordinates, valueLabelString
 } from "./graph-utils"
 
 describe("formatValue", () => {
@@ -401,4 +402,57 @@ describe("lineToAxisIntercepts", () => {
       .toBe(false)
   })
 
+})
+
+describe("setPointCoordinates point shapes", () => {
+  /*
+   * This path both creates and moves points, so it is what a newly created point gets its style
+   * from. A shape supplied only by the selection-restyle path leaves every new point a circle until
+   * something unrelated restyles it -- adding a case to a plot with shapes is enough to show it.
+   */
+  const makeRenderer = (caseIDs: string[]) => {
+    const styles: Record<string, IPointStyle> = {}
+    return {
+      styles,
+      anchor: { x: 0.5, y: 0.5 },
+      forEachPoint: (fn: (point: any, metadata: any) => void) => {
+        caseIDs.forEach((caseID, i) => fn({ id: caseID }, { caseID, plotNum: 0, x: 10, y: 10 }))
+      },
+      transition: (fn: () => void) => fn(),
+      setPointPosition: jest.fn(),
+      setPointScale: jest.fn(),
+      setPositionOrTransition: jest.fn(),
+      setPointStyle: (point: any, style: IPointStyle) => { styles[point.id] = style }
+    }
+  }
+
+  const run = (renderer: any, getLegendShape?: (anID: string) => any) => {
+    setPointCoordinates({
+      renderer: renderer as any,
+      pointRadius: 5,
+      selectedPointRadius: 7,
+      pointColor: "#123456",
+      pointStrokeColor: "#000000",
+      getScreenX: () => 20,
+      getScreenY: () => 30,
+      getLegendShape,
+      getAnimationEnabled: () => false
+    })
+  }
+
+  it("styles each point with the shape it resolves for that case", () => {
+    const renderer = makeRenderer(["c1", "c2"])
+    run(renderer, (anID: string) => (anID === "c1" ? "star" : "triangle"))
+
+    expect(renderer.styles.c1.shape).toBe("star")
+    expect(renderer.styles.c2.shape).toBe("triangle")
+  })
+
+  it("leaves the shape alone when no resolver is supplied", () => {
+    // callers that predate shapes must keep drawing whatever the renderer already had
+    const renderer = makeRenderer(["c1"])
+    run(renderer, undefined)
+
+    expect(renderer.styles.c1).not.toHaveProperty("shape")
+  })
 })

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -15,6 +15,7 @@ import {IDataConfigurationModel} from "../../data-display/models/data-configurat
 import { PointRendererBase } from "../../data-display/renderer"
 import { IGraphDataConfigurationModel } from "../models/graph-data-configuration-model"
 import { GraphLayout } from "../models/graph-layout"
+import { PointShape } from "../../../utilities/point-shape-utils"
 
 /**
  * Utility routines having to do with graph entities
@@ -503,6 +504,9 @@ export interface ISetPointSelection {
   selectedPointRadius: number,
   pointColor: string,
   pointStrokeColor: string,
+  // The shape used where the legend assigns none -- no legend attribute, or a legend whose type
+  // carries no categories. Optional so callers that predate shapes keep drawing circles.
+  pointShape?: PointShape,
   pointDisplayType?: PointDisplayType,
   getPointColorAtIndex?: (index: number) => string
 }

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -504,8 +504,8 @@ export interface ISetPointSelection {
   selectedPointRadius: number,
   pointColor: string,
   pointStrokeColor: string,
-  // The shape used where the legend assigns none -- no legend attribute, or a legend whose type
-  // carries no categories. Optional so callers that predate shapes keep drawing circles.
+  // The shape used where the legend assigns none. Optional so callers that predate shapes keep
+  // drawing circles.
   pointShape?: PointShape,
   pointDisplayType?: PointDisplayType,
   getPointColorAtIndex?: (index: number) => string

--- a/v3/src/components/graph/utilities/graph-utils.ts
+++ b/v3/src/components/graph/utilities/graph-utils.ts
@@ -525,6 +525,12 @@ export interface ISetPointCoordinates {
   getScreenX: ((anID: string) => number | null)
   getScreenY: ((anID: string, plotNum?:number) => number | null)
   getLegendColor?: ((anID: string) => string)
+  /*
+   * The shape for a case, resolved at call time like getLegendColor. This path creates points as
+   * well as moving them, so a shape supplied only by the restyle path would leave every newly
+   * created point a circle until something unrelated restyled it.
+   */
+  getLegendShape?: ((anID: string) => PointShape)
   getAnimationEnabled: () => boolean
   getWidth?: (anID: string) => number | null
   getHeight?: (anID: string, plotNum?:number) => number | null
@@ -533,8 +539,8 @@ export interface ISetPointCoordinates {
 export function setPointCoordinates(props: ISetPointCoordinates) {
   const {
     anchor, dataset, renderer, selectedOnly = false, pointRadius, selectedPointRadius,
-    pointStrokeColor, pointColor, getPointColorAtIndex, getScreenX, getScreenY, getLegendColor, getAnimationEnabled,
-    getWidth, getHeight
+    pointStrokeColor, pointColor, getPointColorAtIndex, getScreenX, getScreenY, getLegendColor, getLegendShape,
+    getAnimationEnabled, getWidth, getHeight
   } = props
 
   const lookupLegendColor = (caseData: CaseData): string => {
@@ -587,7 +593,8 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
             // Points are circles by default but can be changed to bars, so we need to set a width and height. If
             // getWidth and getHeight are not provided, we use pointRadius * 2 for these values.
             width: getWidth?.(caseID) ?? pointRadius * 2,
-            height: getHeight?.(caseID, plotNum) ?? pointRadius * 2
+            height: getHeight?.(caseID, plotNum) ?? pointRadius * 2,
+            ...(getLegendShape ? { shape: getLegendShape(caseID) } : {})
           }
           renderer.setPointStyle(point, style)
           renderer.setPositionOrTransition(point, style, getScreenX(caseID) || 0, getScreenY(caseID, plotNum) || 0)

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -414,6 +414,17 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
       {name: "MapPointLayer [legendColorChange]", fireImmediately: true}, dataConfiguration)
   }, [dataConfiguration, refreshHeatmap, refreshPoints])
 
+  // A shape change alters only how each point is drawn, so the points are restyled without
+  // touching the heatmap, which has no notion of shape.
+  useEffect(() => {
+    return mstReaction(
+      () => dataConfiguration?.legendShapeDomain,
+      () => {
+        refreshPoints(false)
+      },
+      {name: "MapPointLayer [legendShapeChange]"}, dataConfiguration)
+  }, [dataConfiguration, refreshPoints])
+
   // Changes in layout or map pan/zoom require repositioning points
   useEffect(function setupResponsesToLayoutChanges() {
     return reaction(

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -346,6 +346,10 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
     const {latId, longId} = mapLayerModel.pointAttributes || {}
     if (!latId || !longId) return
 
+    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
+    // rather than as a circle until something later restyles it.
+    const shapeIfNoCategory = pointDescription.pointShape
+
     prf.measure("Map.refreshPoints[forEachPoint]", () => {
       renderer.forEachPoint((point: IPoint, metadata: IPointMetadata) => {
         const {caseID} = metadata
@@ -353,6 +357,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
         renderer.setPointStyle(point, {
           radius: dataset?.isCaseSelected(caseID) ? selectedPointRadius : pointRadius,
           fill: lookupLegendColor(metadata),
+          shape: dataConfiguration.getLegendShapeForCase(caseID, shapeIfNoCategory),
           stroke: getLegendColor && dataset?.isCaseSelected(caseID)
             ? defaultSelectedStroke : pointStrokeColor,
           strokeWidth: getLegendColor && dataset?.isCaseSelected(caseID)

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -16,7 +16,7 @@ import { prf } from "../../../utilities/profiler"
 import {DataTip} from "../../data-display/components/data-tip"
 import {CaseData} from "../../data-display/d3-types"
 import {
-  computePointRadius, handleClickOnCase, matchCirclesToData, setPointSelection
+  computePointRadius, handleClickOnCase, legendShapeGetter, matchCirclesToData, setPointSelection
 } from "../../data-display/data-display-utils"
 import { IConnectingLineDescription } from "../../data-display/data-display-types"
 import {isDisplayItemVisualPropsAction} from "../../data-display/models/display-model-actions"
@@ -347,9 +347,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
     const {latId, longId} = mapLayerModel.pointAttributes || {}
     if (!latId || !longId) return
 
-    // Resolved here, alongside the color, so a point created by this path is drawn with its shape
-    // rather than as a circle until something later restyles it.
-    const shapeIfNoCategory = pointDescription.pointShape
+    const getLegendShape = legendShapeGetter(dataConfiguration, pointDescription)
 
     prf.measure("Map.refreshPoints[forEachPoint]", () => {
       renderer.forEachPoint((point: IPoint, metadata: IPointMetadata) => {
@@ -358,7 +356,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
         renderer.setPointStyle(point, {
           radius: dataset?.isCaseSelected(caseID) ? selectedPointRadius : pointRadius,
           fill: lookupLegendColor(metadata),
-          shape: dataConfiguration.getLegendShapeForCase(caseID, shapeIfNoCategory),
+          shape: getLegendShape(caseID),
           stroke: getLegendColor && dataset?.isCaseSelected(caseID)
             ? defaultSelectedStroke : pointStrokeColor,
           strokeWidth: getLegendColor && dataset?.isCaseSelected(caseID)

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -293,6 +293,7 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
         pointRadius: mapLayerModel.getPointRadius(),
         instanceId: dataConfiguration.id,
         pointColor: pointDescription.pointColor,
+        pointShape: pointDescription.pointShape,
         pointStrokeColor: pointDescription.pointStrokeColor,
         startAnimation: mapModel.startAnimation,
         stopAnimation: mapModel.stopAnimation

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -420,15 +420,8 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
       {name: "MapPointLayer [legendColorChange]", fireImmediately: true}, dataConfiguration)
   }, [dataConfiguration, refreshHeatmap, refreshPoints])
 
-  /*
-   * A shape change alters only how each point is drawn, so the points are restyled without touching
-   * the heatmap, which has no notion of shape.
-   *
-   * It goes through refreshPointSelection because that restyles without the heatmap work, not
-   * because it is the only path carrying a shape: refreshPoints writes one too, so that a point it
-   * creates is not drawn as a circle. Both shape sources are observed here -- the per-category
-   * shapes, and the layer's own, which is what a layer with no legend attribute draws throughout.
-   */
+  // A shape change alters only how each point is drawn, so the points are restyled without touching
+  // the heatmap, which has no notion of shape.
   useEffect(() => {
     return mstReaction(
       () => [dataConfiguration?.legendShapeDomain, mapLayerModel.pointDescription.pointShape],

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -424,11 +424,10 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
    * A shape change alters only how each point is drawn, so the points are restyled without touching
    * the heatmap, which has no notion of shape.
    *
-   * It has to go through refreshPointSelection: that is the only path that writes the shape into a
-   * point's style. refreshPoints sets the radius, fill and stroke but not the shape, and style
-   * updates merge, so refreshing after a shape change leaves the old shape in place. Both shape
-   * sources are observed here -- the per-category shapes, and the layer's own, which is what a
-   * layer with no legend attribute draws throughout.
+   * It goes through refreshPointSelection because that restyles without the heatmap work, not
+   * because it is the only path carrying a shape: refreshPoints writes one too, so that a point it
+   * creates is not drawn as a circle. Both shape sources are observed here -- the per-category
+   * shapes, and the layer's own, which is what a layer with no legend attribute draws throughout.
    */
   useEffect(() => {
     return mstReaction(

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -414,16 +414,24 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
       {name: "MapPointLayer [legendColorChange]", fireImmediately: true}, dataConfiguration)
   }, [dataConfiguration, refreshHeatmap, refreshPoints])
 
-  // A shape change alters only how each point is drawn, so the points are restyled without
-  // touching the heatmap, which has no notion of shape.
+  /*
+   * A shape change alters only how each point is drawn, so the points are restyled without touching
+   * the heatmap, which has no notion of shape.
+   *
+   * It has to go through refreshPointSelection: that is the only path that writes the shape into a
+   * point's style. refreshPoints sets the radius, fill and stroke but not the shape, and style
+   * updates merge, so refreshing after a shape change leaves the old shape in place. Both shape
+   * sources are observed here -- the per-category shapes, and the layer's own, which is what a
+   * layer with no legend attribute draws throughout.
+   */
   useEffect(() => {
     return mstReaction(
-      () => dataConfiguration?.legendShapeDomain,
+      () => [dataConfiguration?.legendShapeDomain, mapLayerModel.pointDescription.pointShape],
       () => {
-        refreshPoints(false)
+        refreshPointSelection()
       },
-      {name: "MapPointLayer [legendShapeChange]"}, dataConfiguration)
-  }, [dataConfiguration, refreshPoints])
+      {name: "MapPointLayer [shapeChange]", equals: comparer.structural}, dataConfiguration)
+  }, [dataConfiguration, mapLayerModel, refreshPointSelection])
 
   // Changes in layout or map pan/zoom require repositioning points
   useEffect(function setupResponsesToLayoutChanges() {

--- a/v3/src/components/map/components/map-point-layer.tsx
+++ b/v3/src/components/map/components/map-point-layer.tsx
@@ -302,11 +302,11 @@ export const MapPointLayer = observer(function MapPointLayer({mapLayerModel, lay
       pointDescription, renderer])
 
   const refreshPointSelection = useCallback((caseIdsToUpdate?: Iterable<string>) => {
-    const {pointColor, pointStrokeColor} = pointDescription,
+    const {pointColor, pointStrokeColor, pointShape} = pointDescription,
       selectedPointRadius = mapLayerModel.getPointRadius('select')
     dataConfiguration && setPointSelection({
       renderer, dataConfiguration, pointRadius: mapLayerModel.getPointRadius(),
-      selectedPointRadius, pointColor, pointStrokeColor
+      selectedPointRadius, pointColor, pointStrokeColor, pointShape
     }, caseIdsToUpdate)
   }, [pointDescription, mapLayerModel, dataConfiguration, renderer])
 

--- a/v3/src/components/vars.scss
+++ b/v3/src/components/vars.scss
@@ -90,7 +90,7 @@ $palette-color-row-height: 30px;
 $palette-color-row-margin: 4px;
 
 // Legend-category rows are the same height but sit a little further apart. The rows are flex
-// items, so these margins do not collapse and neighbouring rows sit 2 * this value apart.
+// items, so these margins do not collapse and neighboring rows sit 2 * this value apart.
 $palette-category-row-margin: 3px;
 $palette-category-row-height: $palette-color-row-height + 2 * $palette-category-row-margin; // 36px
 

--- a/v3/src/models/data/category-set.test.ts
+++ b/v3/src/models/data/category-set.test.ts
@@ -378,15 +378,26 @@ describe("CategorySet", () => {
       expect(categories.shapeForCategory("b")).toBe("circle")
     })
 
-    it("stores the default as absence, so unused documents carry nothing", () => {
+    it("carries nothing for a category whose shape was never chosen", () => {
+      const categories = makeSet(["a"])
+      expect(getSnapshot(categories).shapes).toEqual({})
+      // absent means the category has none of its own, so it takes what it is given
+      expect(categories.shapeForCategory("a", "star")).toBe("star")
+    })
+
+    it("stores an explicitly chosen circle, which absence does not stand for", () => {
+      /*
+       * Absence means "inherit the display's shape", so it cannot double as "circle". Dropping the
+       * entry here would read back as the display's shape and leave circle unselectable for a
+       * category whenever the display was set to anything else.
+       */
       const categories = makeSet(["a"])
       runInAction(() => categories.setShapeForCategory("a", "star"))
       expect(getSnapshot(categories).shapes).toEqual({ a: "star" })
 
-      // reverting to the default removes the entry rather than recording "circle"
       runInAction(() => categories.setShapeForCategory("a", "circle"))
-      expect(getSnapshot(categories).shapes).toEqual({})
-      expect(categories.shapeForCategory("a")).toBe("circle")
+      expect(getSnapshot(categories).shapes).toEqual({ a: "circle" })
+      expect(categories.shapeForCategory("a", "star")).toBe("circle")
     })
 
     it("resolves an unrecognized stored shape to the default", () => {

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -234,8 +234,8 @@ export const CategorySet = types.model("CategorySet", {
     return isPointShape(stored) ? stored : shapeIfUnset
   },
   /*
-   * Only the categories carrying an explicit shape. Categories at the default are omitted, so
-   * exports stay empty until a user actually assigns one.
+   * Only the categories carrying a shape of their own. A category the user has never assigned is
+   * absent, so exports stay empty until one is actually chosen.
    *
    * Built with fromEntries: assignment would set the prototype for a category named `__proto__`.
    */
@@ -293,12 +293,13 @@ export const CategorySet = types.model("CategorySet", {
   },
   // Storing the default is stored as absence, so a document only carries the shapes a user chose
   // and a category reverted to circle round-trips as an unset entry.
+  /*
+   * Every choice is stored, circle included. Absence means the category has no shape of its own and
+   * inherits the display's, which is not the same as having been set to a circle: with a display
+   * shape of star, dropping a circle here would read back as star and make circle unselectable.
+   */
   setShapeForCategory(value: string, shape: PointShape) {
-    if (shape && shape !== kDefaultPointShape) {
-      self.shapes.set(value, shape)
-    } else {
-      self.shapes.delete(value)
-    }
+    self.shapes.set(value, shape)
   },
   storeCurrentColorForCategory(value: string) {
     const color = self.colorForCategory(value)

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -291,8 +291,6 @@ export const CategorySet = types.model("CategorySet", {
       self.colors.delete(value)
     }
   },
-  // Storing the default is stored as absence, so a document only carries the shapes a user chose
-  // and a category reverted to circle round-trips as an unset entry.
   /*
    * Every choice is stored, circle included. Absence means the category has no shape of its own and
    * inherits the display's, which is not the same as having been set to a circle: with a display

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -4,7 +4,7 @@ import {
 } from "mobx-state-tree"
 import { kellyColors } from "../../utilities/color-utils"
 import { compareValues } from "../../utilities/data-utils"
-import { kDefaultPointShape, PointShape, pointShapeOrDefault } from "../../utilities/point-shape-utils"
+import { isPointShape, kDefaultPointShape, PointShape, pointShapeOrDefault } from "../../utilities/point-shape-utils"
 import { gLocale } from "../../utilities/translation/locale"
 import { Attribute, IAttribute } from "./attribute"
 import { IDataSet } from "./data-set"
@@ -219,10 +219,19 @@ export const CategorySet = types.model("CategorySet", {
   colorForCategory(category: string) {
     return self.colorMap[category]
   },
-  // Unlike colors, which cycle through a palette by category index, every category starts at the
-  // same default shape, so there is no index-derived fallback to compute.
-  shapeForCategory(category: string): PointShape {
-    return pointShapeOrDefault(self.shapes.get(category))
+  /*
+   * Unlike colors, which cycle through a palette by category index, there is no shape palette --
+   * every category would otherwise start at the same shape, so there is no index-derived fallback
+   * to compute.
+   *
+   * A category with no shape of its own inherits `shapeIfUnset`, which callers set to the
+   * display's own shape. That is what keeps a shape chosen before a legend existed from being
+   * discarded the moment one is added: colors are replaced by something meaningful when a legend
+   * takes over, but shapes would be replaced by nothing.
+   */
+  shapeForCategory(category: string, shapeIfUnset: PointShape = kDefaultPointShape): PointShape {
+    const stored = self.shapes.get(category)
+    return isPointShape(stored) ? stored : shapeIfUnset
   },
   /*
    * Only the categories carrying an explicit shape. Categories at the default are omitted, so

--- a/v3/src/models/data/category-set.ts
+++ b/v3/src/models/data/category-set.ts
@@ -291,11 +291,8 @@ export const CategorySet = types.model("CategorySet", {
       self.colors.delete(value)
     }
   },
-  /*
-   * Every choice is stored, circle included. Absence means the category has no shape of its own and
-   * inherits the display's, which is not the same as having been set to a circle: with a display
-   * shape of star, dropping a circle here would read back as star and make circle unselectable.
-   */
+  // Stores every choice, circle included: absence means the category inherits the display's shape,
+  // so dropping a circle here would read back as whatever the display is set to.
   setShapeForCategory(value: string, shape: PointShape) {
     self.shapes.set(value, shape)
   },

--- a/v3/src/models/data/v2-category-set-importer.test.ts
+++ b/v3/src/models/data/v2-category-set-importer.test.ts
@@ -88,9 +88,15 @@ describe("importV2CategorySet", () => {
       expect(importV2CategorySet(makeAttribute(), undefined, undefined)).toBeUndefined()
     })
 
-    it("drops the default, which is stored as absence", () => {
+    it("keeps an explicitly chosen circle, which absence does not stand for", () => {
+      /*
+       * Absence means the category inherits the display's shape, so a circle in the document is a
+       * choice the user made and not a value to age out. Dropping it here would reinstate the
+       * inherited shape on reload -- a category deliberately set to circle would come back as star
+       * on a display whose shape is star, which is the whole reason the setter stores it.
+       */
       const result = importV2CategorySet(makeAttribute(), undefined, { land: "circle", water: "star" })
-      expect(result?.shapes).toEqual({ water: "star" })
+      expect(result?.shapes).toEqual({ land: "circle", water: "star" })
     })
 
     it("drops a shape this build does not recognize", () => {

--- a/v3/src/models/data/v2-category-set-importer.ts
+++ b/v3/src/models/data/v2-category-set-importer.ts
@@ -1,7 +1,7 @@
 import { colord } from "colord"
 import { kellyColors } from "../../utilities/color-utils"
 import { compareValues } from "../../utilities/data-utils"
-import { isPointShape, kDefaultPointShape } from "../../utilities/point-shape-utils"
+import { isPointShape } from "../../utilities/point-shape-utils"
 import { gLocale } from "../../utilities/translation/locale"
 import { CodapV2ColorMap, ICodapV2CategoryMap, isV2CategoryMap } from "../../v2/codap-v2-data-context-types"
 import { IAttribute } from "./attribute"
@@ -21,14 +21,15 @@ export function importV2CategorySet(
 
   /*
    * Taken as given rather than filtered against the categories currently in the data: every entry
-   * is a deliberate assignment, so a category whose cases are deleted and later restored keeps the
-   * shape the user chose for it. Nothing generates a shape, so there is no automatic value to age
-   * out the way the color loop below ages one out.
+   * is a deliberate assignment, circle included -- absence means a category inherits the display's
+   * shape, so an explicit circle is a real choice and dropping it would put that category back on
+   * whatever the display is set to. Nothing generates a shape, so there is no automatic value to
+   * age out the way the color loop below ages one out.
    */
   // fromEntries: assignment would set the prototype for a category named `__proto__`.
   const shapes: Record<string, string> = Object.fromEntries(
     Object.entries(categoryShapes ?? {})
-      .filter(([, shape]) => isPointShape(shape) && shape !== kDefaultPointShape)
+      .filter(([, shape]) => isPointShape(shape))
   )
 
   let colorMap: CodapV2ColorMap = {}

--- a/v3/src/models/data/v2-category-set-importer.ts
+++ b/v3/src/models/data/v2-category-set-importer.ts
@@ -19,13 +19,8 @@ export function importV2CategorySet(
   // than define an own property, losing that category's color
   const colorEntries: Array<[string, string]> = []
 
-  /*
-   * Taken as given rather than filtered against the categories currently in the data: every entry
-   * is a deliberate assignment, circle included -- absence means a category inherits the display's
-   * shape, so an explicit circle is a real choice and dropping it would put that category back on
-   * whatever the display is set to. Nothing generates a shape, so there is no automatic value to
-   * age out the way the color loop below ages one out.
-   */
+  // Not filtered against the categories currently in the data, unlike the color loop below: nothing
+  // generates a shape, so there is no automatic value to age out.
   // fromEntries: assignment would set the prototype for a category named `__proto__`.
   const shapes: Record<string, string> = Object.fromEntries(
     Object.entries(categoryShapes ?? {})

--- a/v3/src/models/shared/data-set-metadata.test.ts
+++ b/v3/src/models/shared/data-set-metadata.test.ts
@@ -561,13 +561,13 @@ describe("DataSetMetadata", () => {
     expect(tree.metadata.provisionalCategories.size).toBe(0)
   })
 
-  it("does not promote for a shape set back to the default", () => {
+  it("promotes for an explicitly chosen circle", () => {
     const categorySet = tree.metadata.getCategorySet("aId")!
-    // the default is stored as absence, so this leaves nothing worth persisting
+    // circle is a choice like any other and has to survive a reload, so it is worth persisting
     categorySet.setShapeForCategory("1", "circle")
 
-    expect(tree.metadata.attributes.size).toBe(0)
-    expect(tree.metadata.provisionalCategories.size).toBe(1)
+    expect(tree.metadata.attributes.size).toBe(1)
+    expect(tree.metadata.provisionalCategories.size).toBe(0)
   })
 
 })

--- a/v3/src/v2/v2-document-round-trip.test.ts
+++ b/v3/src/v2/v2-document-round-trip.test.ts
@@ -118,6 +118,31 @@ describe("v2 document round-trip of point shapes", () => {
     expect(restoredSet.shapeForCategory("land")).toBe("plus")
   })
 
+  it("brings an explicitly chosen circle back through the round trip", async () => {
+    /*
+     * Absence means the category inherits the display's shape, so a circle has to survive as a
+     * stored value rather than being treated as "nothing to save". Dropped anywhere along the way,
+     * the category comes back inheriting -- showing the display's shape instead of the circle the
+     * user picked. Asserted through the full trip because export and import each decide separately
+     * what is worth keeping.
+     */
+    const { document, data, attrId } = documentWithCategories()
+    // re-read between mutations: the first promotes the provisional set, replacing the instance
+    getMetadataFromDataSet(data)!.getCategorySet(attrId)!.setShapeForCategory("water", "star")
+    getMetadataFromDataSet(data)!.getCategorySet(attrId)!.setShapeForCategory("land", "circle")
+
+    const { restoredData } = await roundTrip(document)
+    const restoredAttr = restoredData.attrFromName("habitat")!
+    const restoredSet = getMetadataFromDataSet(restoredData)!.getCategorySet(restoredAttr.id)!
+
+    // asked for the inherited shape a star display would give it, so an entry that survived as
+    // circle is distinguishable from one that was dropped
+    expect(restoredSet.shapeForCategory("land", "star")).toBe("circle")
+    expect(restoredSet.shapeForCategory("water", "star")).toBe("star")
+    // never assigned, so it still inherits
+    expect(restoredSet.shapeForCategory("both", "star")).toBe("star")
+  })
+
   it("adds nothing to the v2 JSON when no shape is assigned", async () => {
     const { document, data, attrId } = documentWithCategories()
     getMetadataFromDataSet(data)!.getCategorySet(attrId)!.setColorForCategory("land", "#123456")


### PR DESCRIPTION
Draws the seven point shapes in the canvas renderer and makes hit testing shape-aware. Third in the LEADS Point Shapes stack, on top of #2693.

Fixes CODAP-1504.

## Geometry

`data-display/renderer/point-shapes.ts` is the single source of shape geometry for every surface that draws one — the canvas renderer today, the PIXI renderer and the legend keys later. Ported from the design prototype's `js/shapes.js`, whose tuned constants these are.

Circle is the reference and is unchanged from what CODAP has always drawn. Every other shape is normalized to about 90% of the circle's area rather than to equal area: straight edges and points read heavier than a circle of identical ink, so the small negative correction is what makes a triangle look like the same size point as a circle. Bounding boxes therefore differ between shapes, which is intentional.

The triangle is centered on its center of area rather than its bounding box. The prototype centers it on the box, which makes it sit `h/6` low — visible as a downward jump when a category is switched to it. In a scatterplot position is the data, so every shape sits on its centroid.

## Hit testing

A point's hit area is the drawn ink **unioned with** the circle of radius `r` that CODAP has always used, not the ink alone. A plus is narrower than a circle across its notches and a star between its arms, so testing the outline by itself would shrink the target for anyone who chose one — and shape is meant to be a free second encoding channel, not something you pay for in click accuracy. The union keeps every shape at least as easy to hit as a circle while adding the ink that extends past it: a star's tips, a square's corners, a triangle's apex.

This surfaced a latent defect in `pointShapeBoundingRadius`, which took half the larger side of the drawn box. That holds only while the box is centered on the point, and the triangle's is not: its apex sits at `1.47r` while half its width is `1.27r`, so a hit area sized from it stopped short of the apex. It now measures from the vertices. Its test had asserted that the radius covered half the extent, which the old implementation returned by construction — a tautology that no asymmetric shape could fail. That test now measures against the vertices too.

Marquee selection is unaffected: it is forwarded to the background element and never goes through the hit tester, and testing a marquee against point positions rather than outlines is what it should do.

## Scope

Behind the `pointShapes` feature flag, which gates the controls: shapes can only be *assigned* by a
flag-enabled user. Rendering is deliberately not gated, so a document that already carries shapes
draws them for everyone rather than silently rendering as circles for a reader without the flag.
That follows the convention from CODAP-1448 of gating affordances rather than registrations or
rendering.

The canvas renderer is the fallback used when Graphics Acceleration is turned off in Options; the
PIXI/WebGL path is CODAP-1509.

One thing worth a reviewer's eye: `getLegendShape` is called per case inside the coordinate
refresh, which runs for every point on every reposition. With no legend it early-returns after
two lookups; with one it does work comparable to the `getLegendColorForCase` already in that
loop. Not measured.

Reviewing commit by commit is likely easier than the combined diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ctmv18kjkPWnUq5bek5nrH

