### PR TITLE
fix(graph): don't invalidate subplot caches for no-op categories-limit changes

### DIFF
--- a/v3/src/components/data-display/models/data-configuration-model.ts
+++ b/v3/src/components/data-display/models/data-configuration-model.ts
@@ -419,6 +419,25 @@ export const DataConfigurationModel = types
   }))
   .views(self => ({
     /**
+     * Normalizes a categories limit so that limits which cannot affect the result all collapse to
+     * the same value (undefined).
+     *
+     * The limit only changes what categoryArrayForAttrRole returns when there are MORE categories
+     * than the limit — that is the only case where the kOther clamp below applies. Axis code
+     * recomputes the limit from the axis length on every layout change
+     * (floor(axisLength / kDefaultFontHeight)), so during a component resize it ticks over roughly
+     * every 12 pixels. Each distinct value invalidates the subPlotCases cache, and recomputing that
+     * is O(cells x cases) — which is why resizing a graph with categorical axes gets slower with
+     * each added dimension. Collapsing every "long enough to show them all" limit to undefined
+     * keeps those no-op changes from invalidating anything.
+     */
+    effectiveCategoriesLimitForRole(role: AttrRole, limit: number | undefined) {
+      if (limit == null || limit <= 0) return undefined
+      const categoryCount = self.categorySetForAttrRole(role)?.values.length
+      if (categoryCount != null && limit >= categoryCount) return undefined
+      return limit
+    },
+    /**
      * @param role
      * @param emptyCategoryArray
      */
@@ -1098,9 +1117,7 @@ export const DataConfigurationModel = types
       categorySet?.setColorForCategory(cat, color)
     },
     setNumberOfCategoriesLimitForRole(role: AttrRole, limit: number | undefined) {
-      if (limit !== undefined && limit <= 0) {
-        limit = undefined
-      }
+      limit = self.effectiveCategoriesLimitForRole(role, limit)
       self.numberOfCategoriesLimitByRole.set(role, limit)
       self.categoryArrayForAttrRole.invalidate(role)
     },

--- a/v3/src/components/graph/models/graph-data-configuration-model.test.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.test.ts
@@ -74,6 +74,58 @@ describe("DataConfigurationModel", () => {
     ])
   })
 
+  // Regression: the categories limit is derived from the axis length
+  // (floor(axisLength / kDefaultFontHeight)), so it ticks over every ~12px while a component is
+  // being resized. It only changes any result when it is SMALLER than the number of categories, but
+  // it used to be stored verbatim, and every distinct value invalidated the subPlotCases cache —
+  // whose rebuild is O(cells x cases). That is what made resizing a categorical graph crawl.
+  describe("categories limit normalization (resize performance)", () => {
+    const sweepAxisLengths = (config: typeof tree.config, from: number, to: number) => {
+      const kFontHeight = 12
+      for (let axisLength = from; axisLength <= to; axisLength += kFontHeight) {
+        config.setNumberOfCategoriesLimitForRole("x", Math.floor(axisLength / kFontHeight))
+      }
+    }
+
+    it("does not invalidate subplot caches for limits that cannot change the result", () => {
+      const config = tree.config
+      config.setDataset(tree.data, tree.metadata)
+      config.setAttribute("x", { attributeID: "nId" })
+
+      // prime the caches, then watch for recomputation
+      const before = config.caseDataWithSubPlot.map(d => ({ ...d }))
+      let recomputes = 0
+      const dispose = reaction(() => config.caseDataWithSubPlot, () => { recomputes++ })
+
+      // simulate dragging the resize handle across a 300px range; every limit here is far larger
+      // than the handful of categories, so none of them can affect the plotted result
+      sweepAxisLengths(config, 300, 600)
+
+      // no cache invalidation, and the plotted result is unchanged
+      expect(recomputes).toBe(0)
+      expect(config.numberOfCategoriesLimitByRole.get("x")).toBeUndefined()
+      expect(config.caseDataWithSubPlot.map(d => ({ ...d }))).toEqual(before)
+      dispose()
+    })
+
+    it("still applies a limit that is smaller than the number of categories", () => {
+      const config = tree.config
+      config.setDataset(tree.data, tree.metadata)
+      config.setAttribute("x", { attributeID: "nId" })
+
+      const allCategories = config.categoryArrayForAttrRole("x")
+      expect(allCategories.length).toBeGreaterThan(1)
+
+      // a limit below the category count must still clamp (and introduce the kOther bucket)
+      config.setNumberOfCategoriesLimitForRole("x", 1)
+      expect(config.categoryArrayForAttrRole("x").length).toBe(1)
+
+      // and releasing the limit restores the full set
+      config.setNumberOfCategoriesLimitForRole("x", allCategories.length)
+      expect(config.categoryArrayForAttrRole("x")).toEqual(allCategories)
+    })
+  })
+
   it("behaves as expected with dot chart on x axis", () => {
     const config = tree.config
     config.setDataset(tree.data, tree.metadata)

--- a/v3/src/components/graph/models/graph-data-configuration-model.ts
+++ b/v3/src/components/graph/models/graph-data-configuration-model.ts
@@ -703,7 +703,13 @@ export const GraphDataConfigurationModel = DataConfigurationModel
     const baseSetNumberOfCategoriesLimitForRole = self.setNumberOfCategoriesLimitForRole
     return {
       setNumberOfCategoriesLimitForRole(role: AttrRole, limit: number) {
-        if (self.numberOfCategoriesLimitByRole.get(role) !== limit) {
+        // Compare the normalized limit, not the raw one. The raw limit is derived from the axis
+        // length, so it changes every ~12px during a resize even when it is far larger than the
+        // number of categories and therefore cannot change any result. Invalidating on the raw
+        // value blows the subPlotCases cache (O(cells x cases) to rebuild) on every step of a
+        // resize drag, which is what makes split/categorical graphs crawl while being resized.
+        const effectiveLimit = self.effectiveCategoriesLimitForRole(role, limit)
+        if (self.numberOfCategoriesLimitByRole.get(role) !== effectiveLimit) {
           self.subPlotCases.invalidateAll()
           self.cellMap.invalidateAll()
           baseSetNumberOfCategoriesLimitForRole.call(self, role, limit)


### PR DESCRIPTION
## Problem

Resizing a graph component with a categorical axis stalls for seconds at a time, on a dataset of only ~1,500 cases. It reproduces on school Chromebooks and on high-end desktops alike, and scales with the number of plotted dimensions (no attributes: fine; one categorical: slow; two: crawls).

## Cause

The categories limit is derived from the axis length:

```js
// axis-utils.ts:73 (and use-sub-axis.ts:184)
const axisLength = layout.getAxisLength(axisPlace),
      numCategoriesLimit = Math.floor(axisLength / kDefaultFontHeight)
dataConfig?.setNumberOfCategoriesLimitForRole(axisPlaceToAttrRole[axisPlace], numCategoriesLimit)
```

`kDefaultFontHeight` is 12, so the limit ticks over roughly every 12 pixels of a resize drag, on each axis. Any change invalidates the subplot caches:

```js
// graph-data-configuration-model.ts:705
if (self.numberOfCategoriesLimitByRole.get(role) !== limit) {
  self.subPlotCases.invalidateAll()
  self.cellMap.invalidateAll()
```

But the limit only affects anything when it is **smaller** than the number of categories — that is the only branch applying the `kOther` clamp (`data-configuration-model.ts:445`):

```js
if (categoryLimitForRole && resultArray.length > categoryLimitForRole) {
  resultArray.length = categoryLimitForRole
  resultArray[categoryLimitForRole - 1] = kOther
}
```

So once the axis is long enough to show every category, going 40 → 41 → 42 changes nothing, yet still discards a cache whose rebuild is O(cells × cases).

## Fix

Normalize limits that cannot change the result to a single value (`undefined`) so they stop counting as changes. Both the base setter and the graph override compare the normalized value.

## Evidence

From a 45-second Chrome performance trace over the slow interaction (main thread, inclusive):

| Inclusive | Frame |
|---|---|
| 25,404 ms | `batchedUpdates$1` (react-dom) |
| 22,815 ms | `runReactions` (MobX) |
| 22,322 ms | `get caseDataWithSubPlot` — `graph-data-configuration-model.ts:717` |
| 22,271 ms | `calculate` (subPlotCases) — `graph-data-configuration-model.ts:556` |

Self time is almost entirely MobX/MST property reads (`get_`, `getObservablePropValue_`, `hasProp`, `reportObserved`).

## Testing

New regression test simulates dragging a resize handle across a 300px range, stepping the limit the way the axis code does, and counts recomputes of `caseDataWithSubPlot`:

| | recomputes |
|---|---|
| before | 50 |
| after | 0 |

A second test asserts a limit *below* the category count still clamps and still introduces the `kOther` bucket, so existing behavior is preserved.

- `npm run build:tsc` — clean
- `npm run lint` — clean
- `npm run test` — 3759 passing (3757 before, plus the 2 new tests)

## Scope / what this does not fix

This addresses the *trigger*, not the cost. `caseDataWithSubPlot` iterates cells and rescans every case per cell, so it is O(cells × cases), and cell count is multiplicative (`getAllCellKeys`, line 484):

```js
const columnCount = topCatCount * xCatCount
const rowCount    = rightCatCount * yCatCount
const totalCount  = rowCount * columnCount
```

Confirmed on a local build: with one categorical attribute, resizing goes from visibly slow to smooth. With two, it is still slow, because every legitimate recompute is then ~C1 × C2 × N case evaluations.

Making that O(cases) looks feasible — `categoricalValueForCaseInRole()` already returns a case's effective category including the `kOther` bucket, and `cellKeyToString()` sorts its entries so a per-case key would match the per-cell key. I did not attempt it here because it decides which subplot every point belongs to (and therefore which mask clips it), and it has to stay correct for numeric axes (`getCategoriesOptions()` returns `xCats: [""]`, not a category list) and for the `kOther` bucket. That seemed worth a separate change by someone with more context on the splitting rules, ideally with a test asserting the new mapping matches the current one case-for-case.

Happy to adjust or split this differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
